### PR TITLE
Add prep course feature

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,4 +35,4 @@ jobs:
           flake8 python/src tests --count --select=E9,F63,F7,F82 --show-source --statistics
       - name: Lint with flake8
         run: | 
-          flake8 --ignore=E501,W293,W503,W504 python/src tests --show-source
+          flake8 --ignore=E501,W293,W503,W504,E711,E712 python/src tests --show-source

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+minversion = 7.0
+addopts = --cov=python/src --cov-report term-missing
+pythonpath = python/src
+testpaths = tests

--- a/python/src/api_endpoints.py
+++ b/python/src/api_endpoints.py
@@ -26,6 +26,7 @@ from controllers.forloebsskabelon_controller import (
 from controllers.forloeb_controller import (
     create_forloeb,
     create_forloeb_preparation,
+    start_preparation_forloeb,
     get_forloeb,
     get_all_forloeb,
     get_forloeb_with_opgaver,
@@ -138,6 +139,11 @@ def create_forloeb_endpoint():
 @api_endpoints.route('/forloeb-preparation', methods=['POST'])
 def create_forloeb_preparation_endpoint():
     return create_forloeb_preparation()
+
+
+@api_endpoints.route('/forloeb-start', methods=['POST'])
+def start_forloeb_endpoint():
+    return start_preparation_forloeb()
 
 
 @api_endpoints.route('/forloeb', methods=['GET'])

--- a/python/src/api_endpoints.py
+++ b/python/src/api_endpoints.py
@@ -61,7 +61,7 @@ from controllers.opgaveskabelon_controller import (
     delete_opgaveskabelon,
     get_opgaveskabelon
 )
-from utils.mail_service import send_all_mails, get_all_mails, delete_planned_mail
+from utils.mail_service import send_all_mails, get_planned_mails, delete_planned_mail
 
 logger = logging.getLogger(__name__)
 db_client = get_db_client()
@@ -311,7 +311,7 @@ def send_planned_mails_endpoint():
 
 @api_endpoints.route('/cron/get-planned-mails', methods=['GET'])
 def get_planned_mails_endpoint():
-    return get_all_mails()
+    return get_planned_mails()
 
 
 @api_endpoints.route('/mail/delete/<int:mail_id>', methods=['DELETE'])

--- a/python/src/api_endpoints.py
+++ b/python/src/api_endpoints.py
@@ -61,7 +61,7 @@ from controllers.opgaveskabelon_controller import (
     delete_opgaveskabelon,
     get_opgaveskabelon
 )
-from utils.mail_service import send_all_mails, get_planned_mails, delete_planned_mail
+from utils.mail_service import purge_mails, send_all_mails, get_planned_mails, delete_planned_mail
 
 logger = logging.getLogger(__name__)
 db_client = get_db_client()
@@ -312,6 +312,12 @@ def send_planned_mails_endpoint():
 @api_endpoints.route('/cron/get-planned-mails', methods=['GET'])
 def get_planned_mails_endpoint():
     return get_planned_mails()
+
+
+@api_endpoints.route('/cron/purge-mails', methods=['POST'])
+def purge_mails_endpoint():
+    days = request.args.get('days', default=30, type=int)
+    return purge_mails(days)
 
 
 @api_endpoints.route('/mail/delete/<int:mail_id>', methods=['DELETE'])

--- a/python/src/api_endpoints.py
+++ b/python/src/api_endpoints.py
@@ -25,6 +25,7 @@ from controllers.forloebsskabelon_controller import (
 )
 from controllers.forloeb_controller import (
     create_forloeb,
+    create_forloeb_preparation,
     get_forloeb,
     get_all_forloeb,
     get_forloeb_with_opgaver,
@@ -132,6 +133,11 @@ def get_all_opgaver_endpoint():
 @api_endpoints.route('/forloeb', methods=['POST'])
 def create_forloeb_endpoint():
     return create_forloeb()
+
+
+@api_endpoints.route('/forloeb-preparation', methods=['POST'])
+def create_forloeb_preparation_endpoint():
+    return create_forloeb_preparation()
 
 
 @api_endpoints.route('/forloeb', methods=['GET'])

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -171,7 +171,6 @@ def start_preparation_forloeb():
         forloeb.startdate = datetime.fromisoformat(data['startdate'])
         forloeb.enddate = datetime.fromisoformat(data['enddate']) if 'enddate' in data else forloeb.startdate + timedelta(days=forloeb.varighed)
         forloeb.isPreparation = False
-        forloeb.varighed = None  # Clear duration as it's no longer in preparation
         session.commit()
 
         for opgave in forloeb.opgave:

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -187,7 +187,7 @@ def start_preparation_forloeb():
                 subject, message = create_mail_ansvarlig(opgave)
                 plan_mail(opgave.ansvarligEmail, subject, message, opgave_id=opgave.OpgaveID)
 
-        return jsonify({"message": "Forløb started successfully", "startdate": forloeb.startdate.isoformat(), "enddate": forloeb.enddate.isoformat(), "uid": forloeb.ForløbID }), 200
+        return jsonify({"message": "Forløb started successfully", "startdate": forloeb.startdate.isoformat(), "enddate": forloeb.enddate.isoformat(), "uid": forloeb.ForløbID}), 200
     except Exception as e:
         session.rollback()
         return jsonify({"error": str(e)}), 500

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -23,7 +23,8 @@ def create_forloeb():
             enddate=datetime.fromisoformat(data['enddate']),
             admin=data['admin'],
             usermail=data['usermail'],
-            userdq=data['userdq']
+            userdq=data['userdq'],
+            isPreparation=False
         )
         session.add(forloeb)
         session.commit()
@@ -81,6 +82,80 @@ def create_forloeb():
         session.close()
 
 
+def create_forloeb_preparation():
+    session = db_client.get_session()
+    try:
+        data = request.json
+        logger.warning(f"Received data for forløb preparation: {data}")
+        required_fields = ['name', 'admin', 'usermail', 'userdq', 'ForløbsskabelonID']
+        if not all(field in data for field in required_fields):
+            return jsonify({"error": f"Missing required fields: {', '.join(required_fields)}"}), 400
+
+        forløbsskabelon = session.query(Forløbsskabelon).filter_by(ForløbsskabelonID=data['ForløbsskabelonID']).first()
+        if not forløbsskabelon:
+            return jsonify({"error": "Forløbsskabelon not found"}), 404
+
+        forloeb = Forløb(
+            name=data['name'],
+            varighed=forløbsskabelon.varighed,
+            startdate=None,  # Set when started
+            enddate=None,    # Set when started
+            admin=data['admin'],
+            usermail=data['usermail'],
+            userdq=data['userdq'],
+            isPreparation=True
+        )
+        session.add(forloeb)
+        session.commit()
+
+        skabelon_opgave_grupper = session.query(OpgaveGruppe).filter_by(ForløbsskabelonID=forløbsskabelon.ForløbsskabelonID).all()
+        new_opgave_grupper = []
+        for opgave_gruppe in skabelon_opgave_grupper:
+            new_opgave_gruppe = OpgaveGruppe(
+                name=opgave_gruppe.name,
+                letter=opgave_gruppe.letter,
+                ForløbID=forloeb.ForløbID
+            )
+            session.add(new_opgave_gruppe)
+            session.commit()  # Commit to get the new OpgaveGruppeID
+            new_opgave_grupper.append(new_opgave_gruppe)
+
+        for opgave in forløbsskabelon.opgave:
+            # Find the matching OpgaveGruppe by name
+            matching_gruppe = next((g for g in new_opgave_grupper if g.name == opgave.opgavegruppe.name), None)
+            new_opgave = Opgave(
+                title=opgave.title,
+                beskrivelse=opgave.beskrivelse,
+                ansvarlig=opgave.ansvarlig,
+                ansvarligEmail=opgave.ansvarligEmail,
+                relativ_startdag=opgave.relativ_startdag,
+                relativ_slutdag=opgave.relativ_slutdag,
+                result=opgave.result,
+                timestamp=opgave.timestamp,
+                ForløbID=forloeb.ForløbID,
+                OpgaveGruppeID=matching_gruppe.get("OpgaveGruppeID") if matching_gruppe else None
+            )
+            session.add(new_opgave)
+            session.commit()  # Commit to get the new OpgaveID
+
+            ressources = session.query(Ressource).filter_by(OpgaveID=opgave.OpgaveID).all()
+            for ressource in ressources:
+                new_ressource = Ressource(
+                    name=ressource.name,
+                    url=ressource.url,
+                    OpgaveID=new_opgave.OpgaveID  # Use the new OpgaveID
+                )
+                session.add(new_ressource)
+            session.commit()
+
+        return jsonify({"message": "Forløb preparation created successfully", "uid": forloeb.ForløbID}), 201
+    except Exception as e:
+        session.rollback()
+        return jsonify({"error": str(e)}), 500
+    finally:
+        session.close()
+
+
 def get_forloeb(forloeb_id: int):
     session = db_client.get_session()
     try:
@@ -93,8 +168,8 @@ def get_forloeb(forloeb_id: int):
         result = {
             "ForløbID": forloeb.ForløbID,
             "name": forloeb.name,
-            "startdate": forloeb.startdate.isoformat(),
-            "enddate": forloeb.enddate.isoformat(),
+            "startdate": forloeb.startdate.isoformat() if forloeb.startdate else None,
+            "enddate": forloeb.enddate.isoformat() if forloeb.enddate else None,
             "admin": forloeb.admin,
             "usermail": forloeb.usermail,
             "userdq": forloeb.userdq,
@@ -105,7 +180,9 @@ def get_forloeb(forloeb_id: int):
                     "letter": gruppe.letter,
                 }
                 for gruppe in opgave_grupper
-            ]
+            ],
+            "isPreparation": forloeb.isPreparation,
+            "varighed": forloeb.varighed
         }
         return jsonify(result), 200
     except Exception as e:
@@ -122,11 +199,13 @@ def get_all_forloeb():
             {
                 "ForløbID": forloeb.ForløbID,
                 "name": forloeb.name,
-                "startdate": forloeb.startdate.isoformat(),
-                "enddate": forloeb.enddate.isoformat(),
+                "startdate": forloeb.startdate.isoformat() if forloeb.startdate else None,
+                "enddate": forloeb.enddate.isoformat() if forloeb.enddate else None,
                 "admin": forloeb.admin,
                 "usermail": forloeb.usermail,
-                "userdq": forloeb.userdq
+                "userdq": forloeb.userdq,
+                "isPreparation": forloeb.isPreparation,
+                "varighed": forloeb.varighed
             }
             for forloeb in forloeb_list
         ]
@@ -144,7 +223,9 @@ def get_forloeb_with_opgaver():
         forloeb_data = [
             {
                 'ForløbID': forloeb.ForløbID,
-                'name': forloeb.name
+                'name': forloeb.name,
+                'isPreparation': forloeb.isPreparation,
+                'varighed': forloeb.varighed
             } for forloeb in forloeb_list
         ]
         return jsonify(forloeb_data), 200
@@ -166,8 +247,8 @@ def get_forloeb_by_email(mail):
         result = {
             "ForløbID": forloeb.ForløbID,
             "name": forloeb.name,
-            "startdate": forloeb.startdate.isoformat(),
-            "enddate": forloeb.enddate.isoformat(),
+            "startdate": forloeb.startdate.isoformat() if forloeb.startdate else None,
+            "enddate": forloeb.enddate.isoformat() if forloeb.enddate else None,
             "admin": forloeb.admin,
             "usermail": forloeb.usermail,
             "userdq": forloeb.userdq,
@@ -178,7 +259,9 @@ def get_forloeb_by_email(mail):
                     "letter": gruppe.letter,
                 }
                 for gruppe in opgave_grupper
-            ]
+            ],
+            "isPreparation": forloeb.isPreparation,
+            "varighed": forloeb.varighed
         }
         return jsonify(result), 200
     except Exception as e:
@@ -201,8 +284,8 @@ def get_forloeb_by_admin(admin_name):
                 {
                     "ForløbID": forloeb.ForløbID,
                     "name": forloeb.name,
-                    "startdate": forloeb.startdate.isoformat(),
-                    "enddate": forloeb.enddate.isoformat(),
+                    "startdate": forloeb.startdate.isoformat() if forloeb.startdate else None,
+                    "enddate": forloeb.enddate.isoformat() if forloeb.enddate else None,
                     "admin": forloeb.admin,
                     "usermail": forloeb.usermail,
                     "userdq": forloeb.userdq,
@@ -213,7 +296,9 @@ def get_forloeb_by_admin(admin_name):
                             "letter": gruppe.letter,
                         }
                         for gruppe in opgave_grupper
-                    ]
+                    ],
+                    "isPreparation": forloeb.isPreparation,
+                    "varighed": forloeb.varighed
                 }
             )
         return jsonify(result), 200
@@ -251,8 +336,10 @@ def update_forloeb(id):
             return jsonify({"error": "Forløb not found"}), 404
 
         forloeb.name = data.get('name', forloeb.name)
-        forloeb.startdate = data.get('startdate', forloeb.startdate)
-        forloeb.enddate = data.get('enddate', forloeb.enddate)
+        if data.get('startdate'):
+            forloeb.startdate = datetime.fromisoformat(data['startdate'])
+        if data.get('enddate'):
+            forloeb.enddate = datetime.fromisoformat(data['enddate'])
         forloeb.admin = data.get('admin', forloeb.admin)
         forloeb.usermail = data.get('usermail', forloeb.usermail)
         forloeb.userdq = data.get('userdq', forloeb.userdq)

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -49,7 +49,7 @@ def create_forloeb():
 
             for opgave in forløbsskabelon.opgave:
                 # Find the matching OpgaveGruppe by name
-                matching_gruppe = next((g for g in new_opgave_grupper if g.name == opgave.opgavegruppe.name), None)
+                matching_gruppe = next((g for g in new_opgave_grupper if opgave.opgavegruppe and g.name == opgave.opgavegruppe.name), None)
                 new_opgave = Opgave(
                     title=opgave.title,
                     beskrivelse=opgave.beskrivelse,
@@ -122,7 +122,7 @@ def create_forloeb_preparation():
 
         for opgave in forløbsskabelon.opgave:
             # Find the matching OpgaveGruppe by name
-            matching_gruppe = next((g for g in new_opgave_grupper if g.name == opgave.opgavegruppe.name), None)
+            matching_gruppe = next((g for g in new_opgave_grupper if opgave.opgavegruppe and g.name == opgave.opgavegruppe.name), None)
             new_opgave = Opgave(
                 title=opgave.title,
                 beskrivelse=opgave.beskrivelse,

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -46,12 +46,10 @@ def create_forloeb():
                 session.add(new_opgave_gruppe)
                 session.commit()  # Commit to get the new OpgaveGruppeID
                 new_opgave_grupper.append(new_opgave_gruppe)
-                logger.warning(f"Created OpgaveGruppe: {new_opgave_gruppe.name} with ID {new_opgave_gruppe.OpgaveGruppeID}")
 
             for opgave in forløbsskabelon.opgave:
                 # Find the matching OpgaveGruppe by name
                 matching_gruppe = next((g for g in new_opgave_grupper if g.name == opgave.opgavegruppe.name), None)
-                logger.warning(f"Matching gruppe for opgave '{opgave.title}': {matching_gruppe.name if matching_gruppe else 'None'}")
                 new_opgave = Opgave(
                     title=opgave.title,
                     beskrivelse=opgave.beskrivelse,

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -435,18 +435,6 @@ def delete_forloeb(id):
         if not forloeb:
             return jsonify({"error": "Forløb not found"}), 404
 
-        # Delete all related Opgave and Ressource records
-        opgave_grupper = session.query(OpgaveGruppe).filter_by(ForløbID=forloeb.ForløbID).all()
-        for gruppe in opgave_grupper:
-            opgaver = session.query(Opgave).filter_by(OpgaveGruppeID=gruppe.OpgaveGruppeID).all()
-            for opgave in opgaver:
-                ressourcer = session.query(Ressource).filter_by(OpgaveID=opgave.OpgaveID).all()
-                for ressource in ressourcer:
-                    session.delete(ressource)
-                session.delete(opgave)
-            session.delete(gruppe)
-        session.commit()
-
         session.delete(forloeb)
         session.commit()
         return jsonify({"message": "Forløb deleted successfully"}), 200

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -90,17 +90,17 @@ def create_forloeb_preparation():
     try:
         data = request.json
         logger.warning(f"Received data for forløb preparation: {data}")
-        required_fields = ['name', 'admin', 'usermail', 'userdq', 'ForløbsskabelonID']
+        required_fields = ['name', 'admin', 'usermail', 'userdq']
         if not all(field in data for field in required_fields):
             return jsonify({"error": f"Missing required fields: {', '.join(required_fields)}"}), 400
 
-        forløbsskabelon = session.query(Forløbsskabelon).filter_by(ForløbsskabelonID=data['ForløbsskabelonID']).first()
-        if not forløbsskabelon:
-            return jsonify({"error": "Forløbsskabelon not found"}), 404
+        forløbsskabelon = session.query(Forløbsskabelon).filter_by(ForløbsskabelonID=data['ForløbsskabelonID']).first() if 'ForløbsskabelonID' in data else None
+        # if not forløbsskabelon:
+        #     return jsonify({"error": "Forløbsskabelon not found"}), 404
 
         forloeb = Forløb(
             name=data['name'],
-            varighed=forløbsskabelon.varighed,
+            varighed=forløbsskabelon.varighed if forløbsskabelon and forløbsskabelon.varighed else 30,
             startdate=None,  # Set when started
             enddate=None,    # Set when started
             admin=data['admin'],
@@ -110,6 +110,9 @@ def create_forloeb_preparation():
         )
         session.add(forloeb)
         session.commit()
+
+        if not forløbsskabelon:
+            return jsonify({"message": "Forløb preparation created successfully without template", "uid": forloeb.ForløbID}), 201
 
         skabelon_opgave_grupper = session.query(OpgaveGruppe).filter_by(ForløbsskabelonID=forløbsskabelon.ForløbsskabelonID).all()
         new_opgave_grupper = []
@@ -151,7 +154,7 @@ def create_forloeb_preparation():
                 session.add(new_ressource)
             session.commit()
 
-        return jsonify({"message": "Forløb preparation created successfully", "uid": forloeb.ForløbID}), 201
+        return jsonify({"message": "Forløb preparation created successfully with template", "uid": forloeb.ForløbID}), 201
     except Exception as e:
         session.rollback()
         return jsonify({"error": str(e)}), 500

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -2,6 +2,7 @@ from flask import make_response, request, jsonify
 from datetime import datetime, timedelta
 from models import Forløb, Forløbsskabelon, Opgave, Ressource, OpgaveGruppe
 from utils.db_connection import get_db_client
+from utils.mail_service import plan_mail, create_mail_ansvarlig
 import logging
 
 logger = logging.getLogger(__name__)
@@ -45,10 +46,12 @@ def create_forloeb():
                 session.add(new_opgave_gruppe)
                 session.commit()  # Commit to get the new OpgaveGruppeID
                 new_opgave_grupper.append(new_opgave_gruppe)
+                logger.warning(f"Created OpgaveGruppe: {new_opgave_gruppe.name} with ID {new_opgave_gruppe.OpgaveGruppeID}")
 
             for opgave in forløbsskabelon.opgave:
                 # Find the matching OpgaveGruppe by name
                 matching_gruppe = next((g for g in new_opgave_grupper if g.name == opgave.opgavegruppe.name), None)
+                logger.warning(f"Matching gruppe for opgave '{opgave.title}': {matching_gruppe.name if matching_gruppe else 'None'}")
                 new_opgave = Opgave(
                     title=opgave.title,
                     beskrivelse=opgave.beskrivelse,
@@ -59,7 +62,7 @@ def create_forloeb():
                     result=opgave.result,
                     timestamp=opgave.timestamp,
                     ForløbID=forloeb.ForløbID,
-                    OpgaveGruppeID=matching_gruppe.get("OpgaveGruppeID") if matching_gruppe else None
+                    OpgaveGruppeID=matching_gruppe.OpgaveGruppeID if matching_gruppe else None
                 )
                 session.add(new_opgave)
                 session.commit()  # Commit to get the new OpgaveID
@@ -133,7 +136,7 @@ def create_forloeb_preparation():
                 result=opgave.result,
                 timestamp=opgave.timestamp,
                 ForløbID=forloeb.ForløbID,
-                OpgaveGruppeID=matching_gruppe.get("OpgaveGruppeID") if matching_gruppe else None
+                OpgaveGruppeID=matching_gruppe.OpgaveGruppeID if matching_gruppe else None
             )
             session.add(new_opgave)
             session.commit()  # Commit to get the new OpgaveID
@@ -149,6 +152,42 @@ def create_forloeb_preparation():
             session.commit()
 
         return jsonify({"message": "Forløb preparation created successfully", "uid": forloeb.ForløbID}), 201
+    except Exception as e:
+        session.rollback()
+        return jsonify({"error": str(e)}), 500
+    finally:
+        session.close()
+
+
+def start_preparation_forloeb():
+    session = db_client.get_session()
+    try:
+        data = request.json
+        required_fields = ['ForløbID', 'startdate', 'enddate', 'planMails']
+        if not all(field in data for field in required_fields):
+            return jsonify({"error": f"Missing required fields: {', '.join(required_fields)}"}), 400
+
+        forloeb = session.query(Forløb).filter_by(ForløbID=data['ForløbID'], isPreparation=True).first()
+        if not forloeb:
+            return jsonify({"error": "Forløb not found or not in preparation mode"}), 404
+
+        forloeb.startdate = datetime.fromisoformat(data['startdate'])
+        forloeb.enddate = datetime.fromisoformat(data['enddate']) if 'enddate' in data else forloeb.startdate + timedelta(days=forloeb.varighed)
+        forloeb.isPreparation = False
+        forloeb.varighed = None  # Clear duration as it's no longer in preparation
+        session.commit()
+
+        for opgave in forloeb.opgave:
+            opgave.startdato = forloeb.startdate + timedelta(days=opgave.relativ_startdag)
+            opgave.slutdato = opgave.startdato + timedelta(days=opgave.relativ_slutdag)
+            session.commit()
+
+            # Optionally send plan mails
+            if opgave.ansvarligEmail and data.get('planMails') is True:
+                subject, message = create_mail_ansvarlig(opgave)
+                plan_mail(opgave.ansvarligEmail, subject, message, opgave_id=opgave.OpgaveID)
+
+        return jsonify({"message": "Forløb started successfully", "startdate": forloeb.startdate.isoformat(), "enddate": forloeb.enddate.isoformat(), "uid": forloeb.ForløbID }), 200
     except Exception as e:
         session.rollback()
         return jsonify({"error": str(e)}), 500

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -2,7 +2,7 @@ from flask import make_response, request, jsonify
 from datetime import datetime, timedelta
 from models import Forløb, Forløbsskabelon, Opgave, Ressource, OpgaveGruppe
 from utils.db_connection import get_db_client
-from utils.mail_service import plan_mail, create_mail_ansvarlig
+from utils.mail_service import plan_mail, create_mail_ansvarlig, create_mail_forloeb_start
 import logging
 
 logger = logging.getLogger(__name__)
@@ -89,15 +89,11 @@ def create_forloeb_preparation():
     session = db_client.get_session()
     try:
         data = request.json
-        logger.warning(f"Received data for forløb preparation: {data}")
         required_fields = ['name', 'admin', 'usermail', 'userdq']
         if not all(field in data for field in required_fields):
             return jsonify({"error": f"Missing required fields: {', '.join(required_fields)}"}), 400
 
         forløbsskabelon = session.query(Forløbsskabelon).filter_by(ForløbsskabelonID=data['ForløbsskabelonID']).first() if 'ForløbsskabelonID' in data else None
-        # if not forløbsskabelon:
-        #     return jsonify({"error": "Forløbsskabelon not found"}), 404
-
         forloeb = Forløb(
             name=data['name'],
             varighed=forløbsskabelon.varighed if forløbsskabelon and forløbsskabelon.varighed else 30,
@@ -190,6 +186,10 @@ def start_preparation_forloeb():
                 subject, message = create_mail_ansvarlig(opgave)
                 plan_mail(opgave.ansvarligEmail, subject, message, opgave_id=opgave.OpgaveID)
 
+        if data.get('planWelcome') is True:
+            subject, message, attachment = create_mail_forloeb_start(forloeb)
+            plan_mail(forloeb.usermail, subject, message, forloeb_id=forloeb.ForløbID, attachment=attachment)
+
         return jsonify({"message": "Forløb started successfully", "startdate": forloeb.startdate.isoformat(), "enddate": forloeb.enddate.isoformat(), "uid": forloeb.ForløbID}), 200
     except Exception as e:
         session.rollback()
@@ -224,7 +224,14 @@ def get_forloeb(forloeb_id: int):
                 for gruppe in opgave_grupper
             ],
             "isPreparation": forloeb.isPreparation,
-            "varighed": forloeb.varighed
+            "varighed": forloeb.varighed,
+            "pending_emails": [
+                {
+                    "id": mail.MailID,
+                    "recipient": mail.recipient,
+                    "subject": mail.subject
+                } for mail in forloeb.mails if not mail.isSent
+            ]
         }
         return jsonify(result), 200
     except Exception as e:
@@ -340,7 +347,14 @@ def get_forloeb_by_admin(admin_name):
                         for gruppe in opgave_grupper
                     ],
                     "isPreparation": forloeb.isPreparation,
-                    "varighed": forloeb.varighed
+                    "varighed": forloeb.varighed,
+                    "pending_emails": [
+                        {
+                            "id": mail.MailID,
+                            "recipient": mail.recipient,
+                            "subject": mail.subject
+                        } for mail in forloeb.mails if not mail.isSent
+                    ]
                 }
             )
         return jsonify(result), 200
@@ -385,6 +399,11 @@ def update_forloeb(id):
         forloeb.admin = data.get('admin', forloeb.admin)
         forloeb.usermail = data.get('usermail', forloeb.usermail)
         forloeb.userdq = data.get('userdq', forloeb.userdq)
+
+        if len(forloeb.mails) == 0 or all(mail.isSent for mail in forloeb.mails):
+            if data.get('planWelcome') is True:
+                subject, message, attachment = create_mail_forloeb_start(forloeb)
+                plan_mail(forloeb.usermail, subject, message, forloeb_id=forloeb.ForløbID, attachment=attachment)
 
         session.commit()
         return jsonify({"message": "Forløb updated successfully", "uid": forloeb.ForløbID}), 200

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -68,7 +68,7 @@ def create_opgave():
         session.commit()
 
         # Send mail notification to the responsible person
-        if 'startdato' in new_opgave and 'slutdato' in new_opgave and new_opgave.ansvarligEmail is not None and new_opgave.ansvarligEmail != "":
+        if new_opgave.startdato and new_opgave.slutdato and new_opgave.ansvarligEmail and new_opgave.ansvarligEmail != "":
             subject, message = create_mail_ansvarlig(new_opgave)
             planned_mail = plan_mail(new_opgave.ansvarligEmail, subject, message, new_opgave.OpgaveID, new_opgave.ForløbID)
             if not planned_mail:
@@ -201,7 +201,7 @@ def create_opgave_with_opgaveskabelon():
         session.commit()
 
         # Send mail notification to the responsible person
-        if new_opgave.ansvarligEmail is not None and new_opgave.ansvarligEmail != "":
+        if new_opgave.startdato and new_opgave.slutdato and new_opgave.ansvarligEmail and new_opgave.ansvarligEmail != "":
             subject, message = create_mail_ansvarlig(new_opgave)
             planned_mail = plan_mail(new_opgave.ansvarligEmail, subject, message, new_opgave.OpgaveID, new_opgave.ForløbID)
             if not planned_mail:
@@ -550,7 +550,7 @@ def update_opgave(opgave_id):
                     session.commit()
 
         # Send mail notification to the responsible person
-        if is_new_ansvarlig and opgave.ansvarligEmail is not None and opgave.ansvarligEmail != "":
+        if opgave.startdato and opgave.slutdato and is_new_ansvarlig and opgave.ansvarligEmail is not None and opgave.ansvarligEmail != "":
             subject, message = create_mail_ansvarlig(opgave)
             planned_mail = plan_mail(opgave.ansvarligEmail, subject, message, opgave.OpgaveID, opgave.ForløbID)
             if not planned_mail:

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -594,26 +594,6 @@ def notify_expired_tasks():
         now = datetime.now()
         opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result == False, Opgave.ForløbID != None).all()
         logger.info(f"Found {len(opgaver)} expired tasks to notify.")
-        opgave_list = [
-            {
-                'OpgaveID': opg.OpgaveID,
-                'title': opg.title,
-                'beskrivelse': opg.beskrivelse,
-                'note': opg.note,
-                'ansvarlig': opg.ansvarlig,
-                'ansvarligEmail': opg.ansvarligEmail,
-                'startdato': opg.startdato.isoformat() if opg.startdato else None,
-                'slutdato': opg.slutdato.isoformat() if opg.slutdato else None,
-                'relativ_startdag': opg.relativ_startdag,
-                'relativ_slutdag': opg.relativ_slutdag,
-                'result': opg.result,
-                'booking': opg.booking.isoformat() if opg.booking else None,
-                'timestamp': opg.timestamp.isoformat() if opg.timestamp else None,
-                'ForløbID': opg.ForløbID,
-                'ForløbsskabelonID': opg.ForløbsskabelonID
-            } for opg in opgaver
-        ]
-        return jsonify({"message": "Test executed", "expired_tasks_count": len(opgaver), "tasks": opgave_list}), 200
 
         for opgave in opgaver:
             forloeb = session.query(Forløb).filter_by(ForløbID=opgave.ForløbID).first()

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -600,14 +600,14 @@ def notify_expired_tasks():
                 return jsonify({"error": "Forløb not found"}), 404
 
             subject, message = create_mail_expired(forloeb, opgave)
-            mail = send_mail(forloeb.usermail, subject, message)
-            if 'error' in mail:
+            status = send_mail(forloeb.usermail, subject, message)
+            if not status:
                 return jsonify({"error": "Failed to send email"}), 500
 
             if opgave.ansvarligEmail is not None and opgave.ansvarligEmail != "":
                 subject, message = create_mail_expired_ansvarlig(opgave)
-                mail = send_mail(opgave.ansvarligEmail, subject, message)
-                if 'error' in mail:
+                status = send_mail(opgave.ansvarligEmail, subject, message)
+                if not status:
                     return jsonify({"error": "Failed to send email"}), 500
 
         return jsonify({"message": "Expired tasks notifications sent successfully"}), 200

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -70,7 +70,7 @@ def create_opgave():
         # Send mail notification to the responsible person
         if new_opgave.startdato and new_opgave.slutdato and new_opgave.ansvarligEmail and new_opgave.ansvarligEmail != "":
             subject, message = create_mail_ansvarlig(new_opgave)
-            planned_mail = plan_mail(new_opgave.ansvarligEmail, subject, message, new_opgave.OpgaveID, new_opgave.ForløbID)
+            planned_mail = plan_mail(new_opgave.ansvarligEmail, subject, message, opgave_id=new_opgave.OpgaveID)
             if not planned_mail:
                 logger.error("Failed to plan email")
 
@@ -203,7 +203,7 @@ def create_opgave_with_opgaveskabelon():
         # Send mail notification to the responsible person
         if new_opgave.startdato and new_opgave.slutdato and new_opgave.ansvarligEmail and new_opgave.ansvarligEmail != "":
             subject, message = create_mail_ansvarlig(new_opgave)
-            planned_mail = plan_mail(new_opgave.ansvarligEmail, subject, message, new_opgave.OpgaveID, new_opgave.ForløbID)
+            planned_mail = plan_mail(new_opgave.ansvarligEmail, subject, message, opgave_id=new_opgave.OpgaveID)
             if not planned_mail:
                 logger.error("Failed to plan email")
 
@@ -552,7 +552,7 @@ def update_opgave(opgave_id):
         # Send mail notification to the responsible person
         if opgave.startdato and opgave.slutdato and is_new_ansvarlig and opgave.ansvarligEmail is not None and opgave.ansvarligEmail != "":
             subject, message = create_mail_ansvarlig(opgave)
-            planned_mail = plan_mail(opgave.ansvarligEmail, subject, message, opgave.OpgaveID, opgave.ForløbID)
+            planned_mail = plan_mail(opgave.ansvarligEmail, subject, message, opgave_id=opgave.OpgaveID)
             if not planned_mail:
                 logger.error("Failed to plan email")
 

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -68,7 +68,7 @@ def create_opgave():
         session.commit()
 
         # Send mail notification to the responsible person
-        if new_opgave.ansvarligEmail is not None and new_opgave.ansvarligEmail != "":
+        if 'startdato' in new_opgave and 'slutdato' in new_opgave and new_opgave.ansvarligEmail is not None and new_opgave.ansvarligEmail != "":
             subject, message = create_mail_ansvarlig(new_opgave)
             planned_mail = plan_mail(new_opgave.ansvarligEmail, subject, message, new_opgave.OpgaveID, new_opgave.ForløbID)
             if not planned_mail:

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -176,7 +176,7 @@ def create_opgave_with_opgaveskabelon():
         else:
             return jsonify({"error": "Either ForløbID or ForløbsskabelonID is required"}), 400
 
-        if 'OpgaveGruppeID' in data:
+        if 'OpgaveGruppeID' in data and data.get('OpgaveGruppeID') is not None:
             opgavegruppe = session.query(OpgaveGruppe).filter_by(OpgaveGruppeID=data['OpgaveGruppeID']).first()
             if not opgavegruppe:
                 return jsonify({"error": "OpgaveGruppe not found"}), 404
@@ -377,8 +377,8 @@ def get_opgave_by_forloeb_id_admin(forlob_id):
                 } if opgave.opgavegruppe else None,
                 'ansvarlig': opgave.ansvarlig,
                 'ansvarligEmail': opgave.ansvarligEmail,
-                'startdato': opgave.startdato.isoformat(),
-                'slutdato': opgave.slutdato.isoformat(),
+                'startdato': opgave.startdato.isoformat() if opgave.startdato else None,
+                'slutdato': opgave.slutdato.isoformat() if opgave.slutdato else None,
                 'relativ_startdag': opgave.relativ_startdag,
                 'relativ_slutdag': opgave.relativ_slutdag,
                 'result': opgave.result,
@@ -439,8 +439,8 @@ def get_opgave_by_admin(adminmail):  # Admin = ansvarlig in this case, bad namin
                 } if opg.opgavegruppe else None,
                 'ansvarlig': opg.ansvarlig,
                 'ansvarligEmail': opg.ansvarligEmail,
-                'startdato': opg.startdato.isoformat(),
-                'slutdato': opg.slutdato.isoformat(),
+                'startdato': opg.startdato.isoformat() if opg.startdato else None,
+                'slutdato': opg.slutdato.isoformat() if opg.slutdato else None,
                 'relativ_startdag': opg.relativ_startdag,
                 'relativ_slutdag': opg.relativ_slutdag,
                 'result': opg.result,

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -2,7 +2,7 @@ from flask import request, jsonify
 from datetime import datetime
 from models import Opgave, Forløb, Forløbsskabelon, Opgaveskabelon, Ressource, OpgaveGruppe
 from utils.db_connection import get_db_client
-from utils.mail_service import plan_mail, send_mail, create_mail_ansvarlig, create_mail_expired_ansvarlig, create_mail_expired
+from utils.mail_service import plan_mail, create_mail_ansvarlig, create_mail_expired_ansvarlig, create_mail_expired
 import logging
 
 db_client = get_db_client()
@@ -592,7 +592,28 @@ def notify_expired_tasks():
     session = db_client.get_session()
     try:
         now = datetime.now()
-        opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result is False).all()
+        opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result == False, Opgave.ForløbID != None).all()
+        logger.info(f"Found {len(opgaver)} expired tasks to notify.")
+        opgave_list = [
+            {
+                'OpgaveID': opg.OpgaveID,
+                'title': opg.title,
+                'beskrivelse': opg.beskrivelse,
+                'note': opg.note,
+                'ansvarlig': opg.ansvarlig,
+                'ansvarligEmail': opg.ansvarligEmail,
+                'startdato': opg.startdato.isoformat() if opg.startdato else None,
+                'slutdato': opg.slutdato.isoformat() if opg.slutdato else None,
+                'relativ_startdag': opg.relativ_startdag,
+                'relativ_slutdag': opg.relativ_slutdag,
+                'result': opg.result,
+                'booking': opg.booking.isoformat() if opg.booking else None,
+                'timestamp': opg.timestamp.isoformat() if opg.timestamp else None,
+                'ForløbID': opg.ForløbID,
+                'ForløbsskabelonID': opg.ForløbsskabelonID
+            } for opg in opgaver
+        ]
+        return jsonify({"message": "Test executed", "expired_tasks_count": len(opgaver), "tasks": opgave_list}), 200
 
         for opgave in opgaver:
             forloeb = session.query(Forløb).filter_by(ForløbID=opgave.ForløbID).first()
@@ -600,17 +621,17 @@ def notify_expired_tasks():
                 return jsonify({"error": "Forløb not found"}), 404
 
             subject, message = create_mail_expired(forloeb, opgave)
-            status = send_mail(forloeb.usermail, subject, message)
+            status = plan_mail(forloeb.usermail, subject, message, opgave_id=opgave.OpgaveID)
             if not status:
-                return jsonify({"error": "Failed to send email"}), 500
+                return jsonify({"error": "Failed to plan email"}), 500
 
             if opgave.ansvarligEmail is not None and opgave.ansvarligEmail != "":
                 subject, message = create_mail_expired_ansvarlig(opgave)
-                status = send_mail(opgave.ansvarligEmail, subject, message)
+                status = plan_mail(opgave.ansvarligEmail, subject, message, opgave_id=opgave.OpgaveID)
                 if not status:
-                    return jsonify({"error": "Failed to send email"}), 500
+                    return jsonify({"error": "Failed to plan email"}), 500
 
-        return jsonify({"message": "Expired tasks notifications sent successfully"}), 200
+        return jsonify({"message": "Expired tasks notifications planned successfully", "planned_count": len(opgaver)}), 200
     except Exception as e:
         return jsonify({"error": str(e)}), 500
     finally:

--- a/python/src/main.py
+++ b/python/src/main.py
@@ -31,7 +31,7 @@ def create_app():
 
         @app.before_request
         def check_authenticated():
-            if 'user' not in session and request.path not in ['/login', '/auth', '/healthz', '/metrics', '/api/cron/notify-expired-tasks']:
+            if 'user' not in session and request.path not in ['/login', '/auth', '/healthz', '/metrics', '/api/cron/notify-expired-tasks', '/api/cron/send-planned-mails']:
                 return redirect(url_for("login"))
 
         @app.route("/login")

--- a/python/src/models.py
+++ b/python/src/models.py
@@ -10,7 +10,8 @@ class Forløbsskabelon(Base):
     ForløbsskabelonID = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     varighed = Column(Integer, nullable=False)
-    opgave = relationship('Opgave', back_populates='forløbsskabelon')
+    opgave = relationship('Opgave', back_populates='forløbsskabelon', cascade='all, delete')
+    opgave_grupper = relationship('OpgaveGruppe', back_populates='forløbsskabelon', cascade='all, delete')
 
 
 class Forløb(Base):
@@ -23,8 +24,9 @@ class Forløb(Base):
     admin = Column(String, nullable=False)
     usermail = Column(String, nullable=False)
     userdq = Column(String, nullable=False)
-    opgave = relationship('Opgave', back_populates='forløb')
-    mails = relationship('Mail', back_populates='forløb')
+    opgave_grupper = relationship('OpgaveGruppe', back_populates='forløb', cascade='all, delete')
+    opgave = relationship('Opgave', back_populates='forløb', cascade='all, delete')
+    mails = relationship('Mail', back_populates='forløb', cascade='all, delete')
     isPreparation = Column(Boolean, default=True)
 
 
@@ -34,7 +36,7 @@ class Opgaveskabelon(Base):
     title = Column(String, nullable=False)
     beskrivelse = Column(String, nullable=False)
     note = Column(String, nullable=True)
-    ressource = relationship('Ressource', back_populates='opgaveskabelon')
+    ressource = relationship('Ressource', back_populates='opgaveskabelon', cascade='all, delete')
     relativ_slutdag = Column(Integer, nullable=False)
 
 
@@ -52,15 +54,15 @@ class Opgave(Base):
     result = Column(Boolean, nullable=False)
     booking = Column(DateTime)
     timestamp = Column(DateTime, nullable=False)
-    ForløbsskabelonID = Column(Integer, ForeignKey('Forløbsskabelon.ForløbsskabelonID'))
+    ForløbsskabelonID = Column(Integer, ForeignKey('Forløbsskabelon.ForløbsskabelonID', ondelete='CASCADE'))
     forløbsskabelon = relationship('Forløbsskabelon', back_populates='opgave')
-    ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID'))
+    ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID', ondelete='CASCADE'))
     forløb = relationship('Forløb', back_populates='opgave')
-    ressource = relationship('Ressource', back_populates='opgave')
-    OpgaveGruppeID = Column(Integer, ForeignKey('OpgaveGruppe.OpgaveGruppeID'))
+    ressource = relationship('Ressource', back_populates='opgave', cascade='all, delete')
+    OpgaveGruppeID = Column(Integer, ForeignKey('OpgaveGruppe.OpgaveGruppeID', ondelete='CASCADE'))
     opgavegruppe = relationship('OpgaveGruppe', back_populates='opgave')
     note = Column(String, nullable=True)
-    mails = relationship('Mail', back_populates='opgave')
+    mails = relationship('Mail', back_populates='opgave', cascade='all, delete')
 
 
 class Ressource(Base):
@@ -68,20 +70,22 @@ class Ressource(Base):
     RessourceID = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
     url = Column(String, nullable=False)
-    OpgaveID = Column(Integer, ForeignKey('Opgave.OpgaveID'))
+    OpgaveID = Column(Integer, ForeignKey('Opgave.OpgaveID', ondelete='CASCADE'))
     opgave = relationship('Opgave', back_populates='ressource')
-    OpgaveskabelonID = Column(Integer, ForeignKey('Opgaveskabelon.OpgaveskabelonID'))
+    OpgaveskabelonID = Column(Integer, ForeignKey('Opgaveskabelon.OpgaveskabelonID', ondelete='CASCADE'))
     opgaveskabelon = relationship('Opgaveskabelon', back_populates='ressource')
 
 
 class OpgaveGruppe(Base):
     __tablename__ = 'OpgaveGruppe'
     OpgaveGruppeID = Column(Integer, primary_key=True, autoincrement=True)
-    ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID'))
-    ForløbsskabelonID = Column(Integer, ForeignKey('Forløbsskabelon.ForløbsskabelonID'))
+    ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID', ondelete='CASCADE'))
+    forløb = relationship('Forløb', back_populates='opgave_grupper')
+    ForløbsskabelonID = Column(Integer, ForeignKey('Forløbsskabelon.ForløbsskabelonID', ondelete='CASCADE'))
+    forløbsskabelon = relationship('Forløbsskabelon', back_populates='opgave_grupper')
     name = Column(String, nullable=False)
     letter = Column(String, nullable=False)
-    opgave = relationship("Opgave", back_populates="opgavegruppe")
+    opgave = relationship("Opgave", back_populates="opgavegruppe", cascade='all, delete')
 
 
 class Mail(Base):
@@ -94,11 +98,15 @@ class Mail(Base):
     isSent = Column(Boolean, default=False)
     sent = Column(DateTime, nullable=True)
     description = Column(String, nullable=True)
-    OpgaveID = Column(Integer, ForeignKey('Opgave.OpgaveID'), nullable=True)
+    OpgaveID = Column(Integer, ForeignKey('Opgave.OpgaveID', ondelete='CASCADE'), nullable=True)
     opgave = relationship('Opgave', back_populates='mails')
-    ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID'), nullable=True)
+    ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID', ondelete='CASCADE'), nullable=True)
     forløb = relationship('Forløb', back_populates='mails')
-    attachment = relationship('MailAttachment', uselist=False, back_populates='mail')
+    attachments = relationship(
+        'MailAttachment',
+        back_populates='mail',
+        cascade='all, delete-orphan',
+    )
 
 
 class MailAttachment(Base):
@@ -106,5 +114,5 @@ class MailAttachment(Base):
     AttachmentID = Column(Integer, primary_key=True, autoincrement=True)
     filename = Column(String, nullable=False)
     file_data = Column(String, nullable=False)  # Store file data as base64 encoded string
-    MailID = Column(Integer, ForeignKey('Mail.MailID'))
-    mail = relationship('Mail', back_populates='attachment')
+    MailID = Column(Integer, ForeignKey('Mail.MailID', ondelete='CASCADE'), nullable=False)
+    mail = relationship('Mail', back_populates='attachments')

--- a/python/src/models.py
+++ b/python/src/models.py
@@ -17,13 +17,15 @@ class Forløb(Base):
     __tablename__ = 'Forløb'
     ForløbID = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
-    startdate = Column(DateTime, nullable=False)
-    enddate = Column(DateTime, nullable=False)
+    startdate = Column(DateTime, nullable=True)
+    enddate = Column(DateTime, nullable=True)
+    varighed = Column(Integer, nullable=True)
     admin = Column(String, nullable=False)
     usermail = Column(String, nullable=False)
     userdq = Column(String, nullable=False)
     opgave = relationship('Opgave', back_populates='forløb')
     mails = relationship('Mail', back_populates='forløb')
+    isPreparation = Column(Boolean, default=True)
 
 
 class Opgaveskabelon(Base):
@@ -91,6 +93,7 @@ class Mail(Base):
     recipient = Column(String, nullable=False)
     isSent = Column(Boolean, default=False)
     sent = Column(DateTime, nullable=True)
+    description = Column(String, nullable=True)
     OpgaveID = Column(Integer, ForeignKey('Opgave.OpgaveID'), nullable=True)
     opgave = relationship('Opgave', back_populates='mails')
     ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID'), nullable=True)

--- a/python/src/models.py
+++ b/python/src/models.py
@@ -98,3 +98,13 @@ class Mail(Base):
     opgave = relationship('Opgave', back_populates='mails')
     ForløbID = Column(Integer, ForeignKey('Forløb.ForløbID'), nullable=True)
     forløb = relationship('Forløb', back_populates='mails')
+    attachment = relationship('MailAttachment', uselist=False, back_populates='mail')
+
+
+class MailAttachment(Base):
+    __tablename__ = 'MailAttachment'
+    AttachmentID = Column(Integer, primary_key=True, autoincrement=True)
+    filename = Column(String, nullable=False)
+    file_data = Column(String, nullable=False)  # Store file data as base64 encoded string
+    MailID = Column(Integer, ForeignKey('Mail.MailID'))
+    mail = relationship('Mail', back_populates='attachment')

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -1,7 +1,7 @@
 from flask import jsonify
 import logging
 import requests
-from datetime import datetime
+from datetime import datetime, timedelta
 from utils.config import MAIL_SERVICE_URL, MAIL_SERVICE_SENDER
 from models import Mail, MailAttachment
 from utils.db_connection import get_db_client
@@ -235,5 +235,27 @@ def delete_planned_mail(mail_id):
     except Exception as e:
         session.rollback()
         return jsonify({"message": "Error deleting planned email", "error": str(e)}), 500
+    finally:
+        session.close()
+
+
+def purge_mails(days=30):
+    """
+    Deletes emails older than the specified number of days.
+    Parameters:
+        days (int): The age in days beyond which emails should be deleted.
+    """
+    session = db_client.get_session()
+    try:
+        threshold_date = datetime.now() - timedelta(days=days)
+        old_mails = session.query(Mail).filter(Mail.created < threshold_date).all()
+        for mail in old_mails:
+            session.delete(mail)
+        session.commit()
+        return jsonify({"message": f"Deleted mails older than {days} days", "deleted_count": len(old_mails)}), 200
+    except Exception as e:
+        session.rollback()
+        logger.error(f"Error purging old emails: {e}")
+        return jsonify({"message": "Error purging old emails", "error": str(e)}), 500
     finally:
         session.close()

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -21,14 +21,6 @@ def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None
     """
     session = db_client.get_session()
     try:
-        if attachment is not None:
-            attachment = MailAttachment(
-                filename=attachment['filename'],
-                file_data=attachment['content']
-            )
-            session.add(attachment)
-            session.commit()
-
         mail = Mail(
             subject=subject,
             body=message,
@@ -38,9 +30,20 @@ def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None
             ForløbID=forloeb_id
         )
         session.add(mail)
-        session.commit()
+        session.commit()  # Commit to get MailID
+
+        if attachment is not None:
+            mail_attachment = MailAttachment(
+                filename=attachment['filename'],
+                file_data=attachment['content'],
+                MailID=mail.MailID  # Link attachment to mail
+            )
+            session.add(mail_attachment)
+            session.commit()
+
     except Exception as e:
         session.rollback()
+        logger.error(f"Error planning email to {recipient_email}: {e}")
         raise e
     else:
         return True
@@ -48,51 +51,64 @@ def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None
         session.close()
 
 
-def get_all_mails():
+def get_planned_mails():
     session = db_client.get_session()
     try:
         mails = session.query(Mail).filter_by(isSent=False).all()
         session.commit()
-        # Convert Mail objects to dicts
-        mails_data = [
-            {
+        mails_data = []
+        for mail in mails:
+            # Get attachments for this mail
+            attachments = session.query(MailAttachment).filter_by(MailID=mail.MailID).all()
+            attachments_data = [
+                {
+                    "filename": attachment.filename,
+                    "file_data": attachment.file_data
+                }
+                for attachment in attachments
+            ]
+            mails_data.append({
                 "id": mail.MailID,
                 "subject": mail.subject,
                 "body": mail.body,
                 "recipient": mail.recipient,
-                "created": mail.created.isoformat() if mail.created else None,
                 "isSent": mail.isSent,
-                "sent": mail.sent.isoformat() if mail.sent else None,
-                "OpgaveID": mail.OpgaveID,
-                "ForløbID": mail.ForløbID
-            }
-            for mail in mails
-        ]
-        return jsonify({"message": "Planned emails retrieved successfully", "count": len(mails_data), "data": mails_data}), 200
+                "attachments": attachments_data
+            })
+        return mails_data
     except Exception as e:
+        logger.error(f"Error fetching planned emails: {e}")
         session.rollback()
-        return jsonify({"message": "Error retrieving planned emails", "error": str(e)}), 500
+        return None
     finally:
         session.close()
 
 
 def send_all_mails():
+    mails = get_planned_mails()
+    if mails is None or len(mails) == 0:
+        return jsonify({"message": "No planned emails to send"}), 200
+
     session = db_client.get_session()
+    sent_count = 0
+    total_count = len(mails) if mails else 0
     try:
-        mails = session.query(Mail).filter_by(isSent=False).all()
-        for mail in mails:
-            status = send_mail(mail.recipient, mail.subject, mail.body, attachments=None)
-            mail.isSent = status in [True]
-            session.add(mail)
+        for mail_dict in mails:
+            status = send_mail(mail_dict.get('recipient'), mail_dict.get('subject'), mail_dict.get('body'), attachments=None)
+            # Fetch the actual Mail ORM object
+            mail_obj = session.query(Mail).filter_by(MailID=mail_dict.get('id')).first()
+            if mail_obj:
+                mail_obj.isSent = status
+                if status:
+                    sent_count += 1
         session.commit()
     except Exception as e:
         session.rollback()
-        return jsonify({"message": "Error sending planned emails", "error": e}), 500
+        return jsonify({"message": "Error sending planned emails", "error": str(e)}), 500
     finally:
-        sent_count = len([mail for mail in mails if mail.isSent]) if 'mails' in locals() else 0
-        total_count = len(mails) if 'mails' in locals() else 0
         session.close()
-        return jsonify({"message": "Planned emails sent successfully", "count": total_count, "sent": sent_count}), 200
+
+    return jsonify({"message": "Planned emails sent successfully", "count": total_count, "sent": sent_count}), 200
 
 
 def send_mail(recipient_email, subject, message, attachments=None):
@@ -110,7 +126,8 @@ def send_mail(recipient_email, subject, message, attachments=None):
         "from": MAIL_SERVICE_SENDER,
         "to": recipient_email,
         "title": subject,
-        "body": message
+        "body": message,
+        "attachments": attachments
     }
     if attachments is not None:
         payload["attachments"] = attachments
@@ -118,9 +135,10 @@ def send_mail(recipient_email, subject, message, attachments=None):
     try:
         response = requests.post(MAIL_SERVICE_URL, headers=headers, json=payload)
         response.raise_for_status()
-        return response.json()
+        return True
     except requests.exceptions.RequestException as e:
-        return {"error": str(e)}
+        logger.error(f"Error sending email to {recipient_email}: {e}")
+        return False
 
 
 def create_mail_ansvarlig(new_opgave):

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -1,4 +1,5 @@
 from flask import jsonify
+import base64
 import logging
 import requests
 from datetime import datetime, timedelta
@@ -9,6 +10,48 @@ from utils.pdf import create_pdf
 
 db_client = get_db_client()
 logger = logging.getLogger(__name__)
+
+
+def _to_base64_str(data):
+    if data is None:
+        return None
+    if isinstance(data, str):
+        return data
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        return base64.b64encode(bytes(data)).decode("ascii")
+    raise TypeError(f"Unsupported attachment content type: {type(data)!r}")
+
+
+def _to_bytes(data):
+    if data is None:
+        return None
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        return bytes(data)
+    if isinstance(data, str):
+        # Stored as base64 text in DB
+        return base64.b64decode(data)
+    raise TypeError(f"Unsupported attachment content type: {type(data)!r}")
+
+
+def _attachments_for_transport(attachments):
+    if attachments is None:
+        return None
+    transformed = []
+    for attachment in attachments:
+        if attachment is None:
+            continue
+        filename = attachment.get("filename")
+        content = attachment.get("file_data", attachment.get("content"))
+        content_bytes = _to_bytes(content)
+        if content_bytes is None:
+            raise ValueError("Attachment content is missing")
+
+        # Mail service expects a JSON byte array
+        transformed.append({
+            "filename": filename,
+            "content": {"data": list(content_bytes)},
+        })
+    return transformed
 
 
 def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None, attachment=None):
@@ -33,9 +76,15 @@ def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None
         session.commit()  # Commit to get MailID
 
         if attachment is not None:
+            # `file_data` is stored and transmitted as base64 text.
+            # Sources (e.g. PDF generation) may provide raw bytes.
+            attachment_content = attachment.get('content', attachment.get('file_data'))
+            file_data_b64 = _to_base64_str(attachment_content)
+            if not file_data_b64:
+                raise ValueError("Attachment content is missing or empty")
             mail_attachment = MailAttachment(
                 filename=attachment['filename'],
-                file_data=attachment['content'],
+                file_data=file_data_b64,
                 MailID=mail.MailID  # Link attachment to mail
             )
             session.add(mail_attachment)
@@ -63,7 +112,7 @@ def get_planned_mails():
             attachments_data = [
                 {
                     "filename": attachment.filename,
-                    "file_data": attachment.file_data
+                    "file_data": _to_base64_str(attachment.file_data)
                 }
                 for attachment in attachments
             ]
@@ -132,10 +181,8 @@ def send_mail(recipient_email, subject, message, attachments=None):
         "to": recipient_email,
         "title": subject,
         "body": message,
-        "attachments": attachments
+        "attachments": _attachments_for_transport(attachments)
     }
-    if attachments is not None:
-        payload["attachments"] = attachments
 
     try:
         response = requests.post(MAIL_SERVICE_URL, headers=headers, json=payload)

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -43,9 +43,6 @@ def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None
         session.rollback()
         raise e
     else:
-        print(" ")
-        logger.info(f"New mail planned to {recipient_email} with subject: '{subject}'")
-        print(" ")
         return True
     finally:
         session.close()

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -94,7 +94,12 @@ def send_all_mails():
     total_count = len(mails) if mails else 0
     try:
         for mail_dict in mails:
-            status = send_mail(mail_dict.get('recipient'), mail_dict.get('subject'), mail_dict.get('body'), attachments=None)
+            status = send_mail(
+                mail_dict.get('recipient'),
+                mail_dict.get('subject'),
+                mail_dict.get('body'),
+                attachments=mail_dict.get('attachments', None)
+            )
             # Fetch the actual Mail ORM object
             mail_obj = session.query(Mail).filter_by(MailID=mail_dict.get('id')).first()
             if mail_obj:
@@ -134,10 +139,15 @@ def send_mail(recipient_email, subject, message, attachments=None):
 
     try:
         response = requests.post(MAIL_SERVICE_URL, headers=headers, json=payload)
+        # Print response content regardless of status code
+        if response.status_code != 200:
+            logger.error(f"Mail service response ({response.status_code}): {response.text}")
         response.raise_for_status()
         return True
     except requests.exceptions.RequestException as e:
         logger.error(f"Error sending email to {recipient_email}: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            logger.error(f"Mail service error response ({e.response.status_code}): {e.response.text}")
         return False
 
 

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -3,7 +3,7 @@ import logging
 import requests
 from datetime import datetime
 from utils.config import MAIL_SERVICE_URL, MAIL_SERVICE_SENDER
-from models import Mail
+from models import Mail, MailAttachment
 from utils.db_connection import get_db_client
 from utils.pdf import create_pdf
 
@@ -11,7 +11,7 @@ db_client = get_db_client()
 logger = logging.getLogger(__name__)
 
 
-def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None):
+def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None, attachment=None):
     """
     Adds an email to DB to be sent at a later point.
     Parameters:
@@ -21,6 +21,14 @@ def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None
     """
     session = db_client.get_session()
     try:
+        if attachment is not None:
+            attachment = MailAttachment(
+                filename=attachment['filename'],
+                file_data=attachment['content']
+            )
+            session.add(attachment)
+            session.commit()
+
         mail = Mail(
             subject=subject,
             body=message,
@@ -35,7 +43,9 @@ def plan_mail(recipient_email, subject, message, opgave_id=None, forloeb_id=None
         session.rollback()
         raise e
     else:
+        print(" ")
         logger.info(f"New mail planned to {recipient_email} with subject: '{subject}'")
+        print(" ")
         return True
     finally:
         session.close()
@@ -180,12 +190,14 @@ def create_mail_expired(forloeb, opgave):
 
 def create_mail_forloeb_start(forloeb):
     forloeb = {
+        "id": forloeb.ForløbID,
+        "name": forloeb.name,
         "userdq": forloeb.userdq,
-        "startdato": forloeb.startdato
+        "startdate": forloeb.startdate
     }
     subject = "Dit onboardingforløb er startet"
     pdf = create_pdf(forloeb['id'])
-    attachments = {"filename": "onboarding_forloeb.pdf", "content": pdf}
+    attachment = {"filename": "onboarding_forloeb.pdf", "content": pdf}
     message = str(
         f"Hej {forloeb['name']}," + "\n\n" +
         "Velkommen til Randers Kommune! Dit onboardingforløb er nu startet." + "\n\n" +
@@ -193,7 +205,7 @@ def create_mail_forloeb_start(forloeb):
         "Du kan også tilgå dit forløbet her: http://onboarding.data.randers.dk/ - kræver login med din medarbejderkonto.\n" +
         "\nVenlig hilsen,\nRanders Kommune"
     )
-    return subject, message, attachments
+    return subject, message, attachment
 
 
 def delete_planned_mail(mail_id):

--- a/python/src/utils/pdf.py
+++ b/python/src/utils/pdf.py
@@ -11,6 +11,8 @@ def create_pdf(forloeb_id):
     forloeb = forloeb_response[0].get_json() if isinstance(forloeb_response, tuple) else forloeb_response.get_json()
     opgaver_response = get_opgave_by_forloeb_id(forloeb_id)
     opgaver = opgaver_response[0].get_json() if isinstance(opgaver_response, tuple) else opgaver_response.get_json()
+    if "error" not in opgaver:
+        opgaver = sorted(opgaver, key=lambda x: x["startdato"])
 
     # Initialize FPDF
     pdf = FPDF()

--- a/tests/mail_service_attachment_encoding_test.py
+++ b/tests/mail_service_attachment_encoding_test.py
@@ -1,0 +1,124 @@
+import base64
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import requests
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from python.src.models import Base, Mail, MailAttachment
+from python.src.utils import mail_service
+
+
+class _TestDbClient:
+    def __init__(self, engine):
+        self.engine = engine
+
+    def get_session(self):
+        return Session(self.engine)
+
+
+def test_plan_mail_encodes_bytes_attachment_to_base64(monkeypatch):
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    test_db_client = _TestDbClient(engine)
+    monkeypatch.setattr(mail_service, "db_client", test_db_client)
+
+    raw = b"hello"
+    attachment = {"filename": "greeting.txt", "content": raw}
+
+    mail_service.plan_mail(
+        recipient_email="someone@example.com",
+        subject="Subject",
+        message="Body",
+        attachment=attachment,
+    )
+
+    session = test_db_client.get_session()
+    stored = session.query(MailAttachment).first()
+    assert stored is not None
+    assert isinstance(stored.file_data, str)
+    assert stored.file_data == base64.b64encode(raw).decode("ascii")
+    session.close()
+
+
+def test_plan_mail_keeps_string_attachment_as_is(monkeypatch):
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    test_db_client = _TestDbClient(engine)
+    monkeypatch.setattr(mail_service, "db_client", test_db_client)
+
+    b64 = base64.b64encode(b"data").decode("ascii")
+    attachment = {"filename": "a.bin", "content": b64}
+
+    mail_service.plan_mail(
+        recipient_email="someone@example.com",
+        subject="Subject",
+        message="Body",
+        attachment=attachment,
+    )
+
+    session = test_db_client.get_session()
+    stored = session.query(MailAttachment).first()
+    assert stored is not None
+    assert stored.file_data == b64
+    session.close()
+
+
+def test_get_planned_mails_normalizes_legacy_bytes_in_db(monkeypatch):
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    test_db_client = _TestDbClient(engine)
+    monkeypatch.setattr(mail_service, "db_client", test_db_client)
+
+    raw = b"legacy"
+    session = test_db_client.get_session()
+    mail = Mail(
+        created=datetime.now(),
+        subject="Subject",
+        body="Body",
+        recipient="someone@example.com",
+        isSent=False,
+    )
+    mail.attachments.append(MailAttachment(filename="x.bin", file_data=raw))
+    session.add(mail)
+    session.commit()
+    session.close()
+
+    mails = mail_service.get_planned_mails()
+    assert len(mails) == 1
+    assert len(mails[0]["attachments"]) == 1
+    assert mails[0]["attachments"][0]["file_data"] == base64.b64encode(raw).decode("ascii")
+
+
+def test_send_mail_transports_attachments_as_json_byte_array(monkeypatch):
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        res = MagicMock()
+        res.status_code = 200
+        res.text = "OK"
+        res.raise_for_status.return_value = None
+        return res
+
+    monkeypatch.setattr(mail_service, "MAIL_SERVICE_URL", "http://mailservice.test/send")
+    monkeypatch.setattr(mail_service, "MAIL_SERVICE_SENDER", "sender@example.com")
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    raw = b"ABC"
+    b64 = base64.b64encode(raw).decode("ascii")
+    ok = mail_service.send_mail(
+        "to@example.com",
+        "Subject",
+        "Body",
+        attachments=[{"filename": "a.bin", "file_data": b64}],
+    )
+    assert ok is True
+    assert captured["json"]["attachments"] == [{"filename": "a.bin", "content": {"data": [65, 66, 67]}}]

--- a/tests/mail_service_delete_test.py
+++ b/tests/mail_service_delete_test.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from python.src.models import Base, Mail, MailAttachment
+from python.src.utils import mail_service
+
+
+class _TestDbClient:
+    def __init__(self, engine):
+        self.engine = engine
+
+    def get_session(self):
+        return Session(self.engine)
+
+
+def test_delete_planned_mail_deletes_attachments(monkeypatch):
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    test_db_client = _TestDbClient(engine)
+    monkeypatch.setattr(mail_service, "db_client", test_db_client)
+
+    # Seed: one unsent mail with one attachment
+    session = test_db_client.get_session()
+    mail = Mail(
+        created=datetime.now(),
+        subject="Subject",
+        body="Body",
+        recipient="someone@example.com",
+        isSent=False,
+    )
+    mail.attachments.append(MailAttachment(filename="a.txt", file_data="ZGF0YQ=="))
+    session.add(mail)
+    session.commit()
+    mail_id = mail.MailID
+    session.close()
+
+    # Call under a Flask app context (jsonify requires it)
+    app = Flask(__name__)
+    with app.app_context():
+        _, status = mail_service.delete_planned_mail(mail_id)
+        assert status == 200
+
+    # Verify both mail and attachments are gone
+    session = test_db_client.get_session()
+    assert session.query(Mail).filter_by(MailID=mail_id).first() is None
+    assert session.query(MailAttachment).filter_by(MailID=mail_id).count() == 0
+    session.close()

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -230,7 +230,7 @@ p > a:hover {
         }
     }
 
-    .navbar .item.selected, .navItem.selected {
+    .navbar .item.router-link-active, .navItem.router-link-active {
         background-color: var(--color-navbar-item-selected);
     }
 
@@ -244,7 +244,7 @@ p > a:hover {
         padding-top: 1.5rem;
     }
 
-    .navbar .item:hover:not(.selected), .navItem:hover:not(.selected) {
+    .navbar .item:hover:not(.router-link-active), .navItem:hover:not(.router-link-active) {
         background-color: var(--color-navbar-item-hover);
         cursor: pointer;
     }

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -534,7 +534,7 @@ p > a:hover {
     justify-content: center;
 }
 .card-titles * {
-    white-space: wrap;
+    white-space: normal;
     overflow: hidden;
     text-overflow: ellipsis;
 }

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -64,8 +64,8 @@ body.onboarding-theme-randers {
     --color-button-hover-dark: rgb(89, 99, 119);
     --color-button-red: #be3b3b;
     --color-button-red-hover: #d15858;
-    --color-button-yellow: #bca002;
-    --color-button-yellow-hover: #e7cc42;
+    --color-button-yellow: #a58b02;
+    --color-button-yellow-hover: #bca002;
     --color-button-disabled: rgb(237, 229, 220, 0);
     --color-floating-button: rgb(124, 121, 120);
     --color-floating-button-hover: rgb(144, 139, 137);
@@ -607,6 +607,8 @@ button[type="submit"] {
     }
     .button.hollow.red { border: 0.1rem solid var(--color-button-red); color: var(--color-button-red) }
     .button.hollow.red:hover { border: 0.1rem solid var(--color-button-red-hover); color: var(--color-button-red-hover) }
+    .button.hollow.yellow { border: 0.1rem solid var(--color-button-yellow); color: var(--color-button-yellow) }
+    .button.hollow.yellow:hover { border: 0.1rem solid var(--color-button-yellow-hover); color: var(--color-button-yellow-hover) }
     .button.dashed { border: 0.1rem dashed var(--color-button); color: var(--color-button) }
     .button.dashed:hover { border: 0.1rem dashed var(--color-button-hover); color: var(--color-button-hover) }
 

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -394,9 +394,11 @@ p > a:hover {
 
     margin-top:0;
     margin-bottom: 0;
-    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    display: flex;
+    gap: 0.5rem;
 }
 .card-title ~ .card-subtitle {
     margin-top: 0.4rem;
@@ -566,6 +568,17 @@ p > a:hover {
 .card-content .buttons {
     justify-content: flex-end;
     margin-top: 2rem;
+}
+
+/* Tags */
+
+.tag {
+    font-size: 0.75em;
+    font-weight: 600;
+    color: var(--color-button-text);
+    background-color: var(--color-button-yellow);
+    padding: 0.2rem 0.5rem;
+    border-radius: 0.2rem;
 }
 
 

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -580,6 +580,13 @@ p > a:hover {
     padding: 0.2rem 0.5rem;
     border-radius: 0.2rem;
 }
+.tag.blue {
+    background-color: var(--color-button);
+}
+.tag.gray {
+    background-color: var(--color-card-dark);
+    color: var(--color-text-faded);
+}
 
 
 /* Buttons + Inputs */

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -543,6 +543,7 @@ p > a:hover {
     display: flex;
     flex-direction: row;
     gap: 1rem;
+    white-space: nowrap;
 }
 
 .card-content .card-details {

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -328,6 +328,9 @@ p > a:hover {
     }
 
 @media only screen and (min-width: 768px) {
+    a:has(.card) {
+        max-width: 38rem;
+    }
     .card, .notification, .textbox {
         max-width: 38rem;
     }
@@ -478,7 +481,6 @@ p > a:hover {
 .card-content, .card-details {
     max-height: calc(auto);
     color: var(--color-card-text);
-    white-space: nowrap;
 }
 
     .card:not(.expand-content) .card-content:not(.always-show) {
@@ -585,9 +587,13 @@ p > a:hover {
     background-color: var(--color-button-yellow);
     padding: 0.2rem 0.5rem;
     border-radius: 0.2rem;
+    user-select: none;
 }
 .tag.blue {
     background-color: var(--color-button);
+}
+.tag.green {
+    background-color: var(--color-progression);
 }
 .tag.gray {
     background-color: var(--color-card-dark);
@@ -603,6 +609,7 @@ button[type="submit"] {
     font-size: 1em;
     font-weight: 500;
     border: 0.1rem solid var(--color-button);
+    user-select: none;
 }
 
 .button {
@@ -613,6 +620,7 @@ button[type="submit"] {
     color:var(--color-button-text);
     cursor: pointer;
     border: 0.1rem solid var(--color-button);
+    user-select: none;
 }
 
     .button:hover {
@@ -1031,6 +1039,10 @@ textarea:not(:placeholder-shown) + .floating-label {
 }
 .center {
     text-align: center;
+}
+
+.nowrap {
+    white-space: nowrap;
 }
 
 .thin {

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -361,12 +361,14 @@ p > a:hover {
 .card-header {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
     height: 4.5rem;
+    width: 100%;
+    position: relative;
+    padding: 0rem 1.2rem;
 }
 
 .card-header:first-child {
-    margin-left: 1.2rem;
+    flex-grow: 1;
 }
 
 .card-icon {
@@ -394,8 +396,6 @@ p > a:hover {
 
     margin-top:0;
     margin-bottom: 0;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 
     display: flex;
     gap: 0.5rem;
@@ -478,6 +478,7 @@ p > a:hover {
 .card-content, .card-details {
     max-height: calc(auto);
     color: var(--color-card-text);
+    white-space: nowrap;
 }
 
     .card:not(.expand-content) .card-content:not(.always-show) {
@@ -526,15 +527,20 @@ p > a:hover {
 
 .card-titles {
     flex-grow: 1;
-    max-width: calc(100% - 14rem);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+.card-titles * {
+    white-space: wrap;
     overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .card-header .card-details {
     display: flex;
     flex-direction: row;
     gap: 1rem;
-    margin: 1.5rem;
 }
 
 .card-content .card-details {

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -1150,6 +1150,7 @@ textarea:not(:placeholder-shown) + .floating-label {
     z-index: 1;
     transform: translate(calc(50% - 1rem), -2rem);
     opacity: 0.8;
+    pointer-events: none;
 }
 .link .tooltip-display {
     transform: translate(-1rem, -3rem);

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -96,7 +96,7 @@
 
             <div class="card-titles">
                 <p class="card-title">
-                    {{ name != '' ? name :  'Forløb uden titel' }} {{ props.isPreparation ? '(Under forberedelse)' : '' }}
+                    <span>{{ name != '' ? name :  'Forløb uden titel' }}</span><span class="tag" v-if="props.isPreparation">Under forberedelse</span>
                 </p>
                 <p v-if="title" class="card-subtitle">
                     {{ title }}

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -34,10 +34,6 @@
         deadline: {
             type: Date
         },
-        color: {
-            type: String,
-            default: '000'
-        },
         disableInteraction: {
             type: Boolean,
             default: false

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -131,7 +131,7 @@
                 </p>
             </div>
 
-            <div class="card-details" v-if="props.duration == null">
+            <div class="card-details" v-if="!isTemplate && !isPreparation">
 
                 <div class="tooltipContainer" v-if="dynamicMails.length > 0">
                     <div class="icon"><i class="fa-solid fa-envelope"></i></div>

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -52,7 +52,7 @@
         },
         mails: {
             type: Array,
-            default: []
+            default: () => []
         }
     })
 

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -3,6 +3,7 @@
     import ProgressBar from './ProgressBar.vue'
 
     import { getOpgaverByForloebID, getOpgaverByForloebsskabelonID } from '@/services/opgaveService.js'
+    import { deleteMail } from '@/services/mailService.js'
 
     const cardRef = ref(null)
     const completedPercentage = ref(0)
@@ -48,11 +49,32 @@
         isPreparation: {
             type: Boolean,
             default: false
+        },
+        mails: {
+            type: Array,
+            default: []
         }
     })
+
     const isTemplate = props.id == null
     const opgaver = ref(props.tasks || null)
     const hasForloebStarted = props.startDate && new Date(props.startDate) <= new Date()
+    const dynamicMails = ref(props.mails)
+
+    const deletePendingEmail = (id) => {
+        if(!confirm('Er du sikker på, at du vil slette denne mail?'))
+            return
+
+        deleteMail({ id: id }).then(response => {
+            dynamicMails.value = dynamicMails.value.filter(mail => mail.id !== id)
+            // const currentPath = { path: router.currentRoute.value.path, query: router.currentRoute.value.query }
+            // router.replace({ path: '/reload' }).then(() => {
+            //     router.replace(currentPath)
+            // })
+        }).catch(error => {
+            console.error('Error deleting mail:', error)
+        })
+    }
 
     onMounted(async () => {
         try {
@@ -90,7 +112,10 @@
 
 <template>
 
-    <router-link :to="{ path: 'forloeb-overview', query: { id: id, tid: tid } }" :class="{ 'disabled': props.disableInteraction }">
+    <component
+        :is="props.disableInteraction ? 'div' : 'router-link'"
+        v-bind="!props.disableInteraction ? { to: { path: 'forloeb-overview', query: { id: id, tid: tid } } } : {}"
+    >
 
     <div :class="['card', 'course', {'dark': props.dark}]" ref="cardRef">
         <div :class="['card-header', {'pointer': !props.disableInteraction}]" @click="expandCard">
@@ -100,6 +125,7 @@
                     <span>{{ name != '' ? name :  'Forløb uden titel' }}</span>
                     <span class="tag" v-if="props.isPreparation">Under forberedelse</span>
                     <span class="tag gray" v-if="isTemplate">Skabelon</span>
+                    <!-- <span class="tag green">Velkomstmail planlagt</span> -->
                 </p>
                 <p v-if="title" class="card-subtitle">
                     {{ title }}
@@ -107,6 +133,25 @@
             </div>
 
             <div class="card-details" v-if="props.duration == null">
+
+                <div class="tooltipContainer" v-if="dynamicMails.length > 0">
+                    <div class="icon"><i class="fa-solid fa-envelope"></i></div>
+                    <div class="text">
+                        <div class="small faded">Mails</div>
+                        <div>{{ dynamicMails.length > 0 ? (dynamicMails.length + ' planlagt') : 'Ingen mails' }}</div>
+                    </div>
+                    
+                    <div class="tooltip">
+                        <div class="mail" v-for="mail in dynamicMails" :key="mail.id">
+                            <div>
+                                <div class="nowrap">Velkomstmail</div>
+                                <div class="mail-recipient nowrap">{{ mail.recipient }}</div>
+                            </div>
+                            <i @click="deletePendingEmail(mail.id)" class="fa-solid fa-circle-xmark"></i>
+                        </div>
+                    </div>
+                </div>
+                
                 <div>
                     <div class="icon"><i class="fa-regular fa-clock"></i></div>
                     <div class="text">
@@ -147,6 +192,58 @@
         </div>
     </div>
 
-    </router-link>
+    </component>
 
 </template>
+<style scoped>
+    .tooltipContainer {
+        position: relative;
+    }
+    .tooltip {
+        background-color: var(--color-card-dark);
+        padding: 0.5rem 0.8rem;
+        border-radius: 0.4rem;
+
+        visibility: hidden;
+        opacity: 0;
+        position: absolute;
+        right: -0.75rem;
+
+        font-size: 0.75rem;
+        cursor: default;
+        text-align: right;
+
+        max-height: 4rem;
+        overflow-y: auto;
+        user-select: text;
+
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.4rem;
+    }
+    .tooltip > .mail {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+    .mail-recipient {
+        max-width: 15rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.9em;
+        font-weight: 400;
+    }
+    .tooltip i {
+        margin-left: 0.5rem;
+        font-size: 1rem;
+    }
+    .tooltip i:hover {
+        color: var(--color-button-red);
+        cursor: pointer;
+    }
+    .tooltipContainer:hover > .tooltip {
+        visibility: visible;
+        opacity: 1;
+    }
+</style>

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -52,6 +52,7 @@
     })
     const isTemplate = props.id == null
     const opgaver = ref(props.tasks || null)
+    const hasForloebStarted = props.startDate && new Date(props.startDate) <= new Date()
 
     onMounted(async () => {
         try {
@@ -141,7 +142,9 @@
             
         </div>
 
-        <div class="card-content always-show" v-if="!duration"><ProgressBar :hideText="true" :percentage="completedPercentage" /></div>
+        <div class="card-content always-show" v-if="!isTemplate && !isPreparation && hasForloebStarted">
+            <ProgressBar :hideText="true" :percentage="completedPercentage" />
+        </div>
     </div>
 
     </router-link>

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -123,9 +123,8 @@
             <div class="card-titles">
                 <p class="card-title">
                     <span>{{ name != '' ? name :  'Forløb uden titel' }}</span>
-                    <span class="tag" v-if="props.isPreparation">Under forberedelse</span>
-                    <span class="tag gray" v-if="isTemplate">Skabelon</span>
-                    <!-- <span class="tag green">Velkomstmail planlagt</span> -->
+                    <div class="tag" v-if="props.isPreparation">Under forberedelse</div>
+                    <div class="tag gray" v-if="isTemplate">Skabelon</div>
                 </p>
                 <p v-if="title" class="card-subtitle">
                     {{ title }}

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -48,6 +48,10 @@
         },
         tasks: {
             type: Array
+        },
+        isPreparation: {
+            type: Boolean,
+            default: false
         }
     })
     const isTemplate = props.id == null
@@ -96,7 +100,7 @@
 
             <div class="card-titles">
                 <p class="card-title">
-                    {{ name != '' ? name :  'Forløb uden titel' }}
+                    {{ name != '' ? name :  'Forløb uden titel' }} {{ props.isPreparation ? '(Under forberedelse)' : '' }}
                 </p>
                 <p v-if="title" class="card-subtitle">
                     {{ title }}

--- a/vue/src/components/CourseItem.vue
+++ b/vue/src/components/CourseItem.vue
@@ -96,7 +96,9 @@
 
             <div class="card-titles">
                 <p class="card-title">
-                    <span>{{ name != '' ? name :  'Forløb uden titel' }}</span><span class="tag" v-if="props.isPreparation">Under forberedelse</span>
+                    <span>{{ name != '' ? name :  'Forløb uden titel' }}</span>
+                    <span class="tag" v-if="props.isPreparation">Under forberedelse</span>
+                    <span class="tag gray" v-if="isTemplate">Skabelon</span>
                 </p>
                 <p v-if="title" class="card-subtitle">
                     {{ title }}

--- a/vue/src/components/CourseList.vue
+++ b/vue/src/components/CourseList.vue
@@ -40,7 +40,8 @@
             :startDate="new Date(course.startdate)"
             :deadline="new Date(course.enddate)"
             :duration="course.varighed"
-            :dark="dark" />
+            :dark="dark"
+            :isPreparation="course.isPreparation" />
     </div>
     <div v-else>
         <p class="indent-tiny">Ingen forløb fundet.</p>

--- a/vue/src/components/CourseList.vue
+++ b/vue/src/components/CourseList.vue
@@ -21,11 +21,11 @@
             type: Boolean,
             default: false
         },
-        color:
-        {
-            type: String,
-            default: null
-        }
+        // color:
+        // {
+        //     type: String,
+        //     default: null
+        // }
     })
 </script>
 

--- a/vue/src/components/CourseList.vue
+++ b/vue/src/components/CourseList.vue
@@ -44,7 +44,7 @@
             :isPreparation="course.isPreparation" />
     </div>
     <div v-else>
-        <p class="indent-tiny">Ingen forløb fundet.</p>
+        <p class="indent-tiny faded">Ingen forløb fundet.</p>
     </div>
 
 </template>

--- a/vue/src/components/CourseList.vue
+++ b/vue/src/components/CourseList.vue
@@ -20,6 +20,11 @@
         {
             type: Boolean,
             default: false
+        },
+        color:
+        {
+            type: String,
+            default: null
         }
     })
 </script>
@@ -35,8 +40,7 @@
             :startDate="new Date(course.startdate)"
             :deadline="new Date(course.enddate)"
             :duration="course.varighed"
-            :dark="dark"
-            color="4c4980" />
+            :dark="dark" />
     </div>
     <div v-else>
         <p class="indent-tiny">Ingen forløb fundet.</p>

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -45,6 +45,7 @@
     const isForloebOngoing = ref(false)
     const isForloebFetched = ref(false)
     const isOpgaverFetched = ref(false)
+    const isUnderPreparation = ref(false)
     const opgaver_all = ref([])
     const completedPercentage = ref(0)
     const opgaver_ongoing = ref([])
@@ -70,8 +71,9 @@
 
                 isForloebFetched.value = true
                 forloeb.value = forloeb_response?.data
-                isForloebCompleted.value = forloeb.value?.enddate ? new Date(forloeb.value.enddate) <= new Date() : false
-                isForloebOngoing.value = forloeb.value?.startdate ? new Date(forloeb.value.startdate) <= new Date() : false
+                isUnderPreparation.value = forloeb.value?.isPreparation || false
+                isForloebCompleted.value = !isUnderPreparation.value && forloeb.value?.enddate ? new Date(forloeb.value.enddate) <= new Date() : false
+                isForloebOngoing.value = !isUnderPreparation.value && forloeb.value?.startdate ? new Date(forloeb.value.startdate) <= new Date() : false
                 forloeb_id.value = forloeb.value?.ForløbID || forloeb.value?.ForløbsskabelonID
                 userTitle.value = forloeb.value?.userdq != '' ? forloeb.value?.userdq : forloeb.value?.usermail
                 if (forloeb.value.opgave_grupper && Array.isArray(forloeb.value.opgave_grupper))
@@ -98,7 +100,7 @@
 
                 // Sort and 
                 // Store opgaver in different arrays based on their status
-                if(props.isTemplate)
+                if(props.isTemplate || isUnderPreparation.value)
                     opgaver_response.data.sort((a, b) => a.relativ_startdag - b.relativ_startdag)
                 else
                     opgaver_response.data.sort((a, b) => new Date(a.slutdato) - new Date(b.slutdato))
@@ -107,9 +109,10 @@
                 opgaver_all.value.sort((a, b) => new Date(a.slutdato) - new Date(b.slutdato))
                 completedPercentage.value = opgaver_all.value.length > 0 ? Math.round(opgaver_all.value.filter(opgave => opgave.result).length / opgaver_all.value.length * 100) : 0
 
-                if(props.isTemplate)
+                if(props.isTemplate || isUnderPreparation.value)
                     opgaver_template.value = opgaver_response.data
                 else
+                {
                     for (const item of opgaver_response.data) {
                         if (item.result)
                             opgaver_completed.value.push(item)
@@ -119,11 +122,14 @@
                         else 
                             opgaver_ongoing.value.push(item)
                     }
-                opgaver_future.value.sort((a, b) => new Date(a.startdato) - new Date(b.startdato))
-                start_message_index.value = opgaver_future.value
-                    .map(opgave => new Date(opgave.startdato) > new Date(forloeb.value.startdate))
-                    .lastIndexOf(true)
-                console.log('Start message index:', start_message_index.value)
+
+                    // Get last index of future tasks that start after forløb start date
+                    opgaver_future.value.sort((a, b) => new Date(a.startdato) - new Date(b.startdato))
+                    start_message_index.value = opgaver_future.value
+                        .map(opgave => new Date(opgave.startdato) > new Date(forloeb.value.startdate))
+                        .lastIndexOf(true)
+                    console.log('Start message index:', start_message_index.value)
+                }
 
                 isOpgaverFetched.value = true
 
@@ -220,6 +226,7 @@
     <p v-if="showDetails" class="indent-tiny bold uppercase p-header-adjust">
         Oversigt
     </p>
+    {{ forloeb }}
     <CourseItem v-if="forloeb != null && isOpgaverFetched && showDetails"
                 :disableInteraction="true" 
                 :dark="true" 
@@ -230,10 +237,11 @@
                 :duration="forloeb.varighed" 
                 :startDate="new Date(forloeb.startdate)" 
                 :deadline="new Date(forloeb.enddate)"
-                :tasks="opgaver_all" />
+                :tasks="opgaver_all"
+                :isPreparation="isUnderPreparation" />
 
-    <Placeholder v-if="!isOpgaverFetched && showDetails" :height="isTemplate ? 4.5 : 7.2" :dark="true" />
-    <ProgressBar v-if="forloeb != null  && !showDetails" :percentage="completedPercentage"></ProgressBar>
+    <Placeholder v-if="!isOpgaverFetched && showDetails" :height="isTemplate || isUnderPreparation ? 4.5 : 7.2" :dark="true" />
+    <ProgressBar v-if="forloeb != null  && !showDetails && !isUnderPreparation" :percentage="completedPercentage"></ProgressBar>
     
     <!-- Admin actions -->
     <div class="buttons" v-if="userInfo.isAdmin && !props.ansvarligView && forloeb != null && isOpgaverFetched">
@@ -249,7 +257,7 @@
                         + Tilføj opgave
         </router-link>
 
-        <router-link :to="`/create-forloeb${isTemplate ? 'sskabelon':''}?edit=true&id=${forloeb_id}`"
+        <router-link :to="`/create-forloeb${isTemplate ? 'sskabelon':''}?edit=true&id=${forloeb_id}&prep=${isUnderPreparation}`"
                      class="button hollow">
                         Redigér {{isForloebCompleted ? ' / genoptag ' : '' }}{{ isTemplate ? 'skabelon' : 'forløb' }}
         </router-link>
@@ -268,7 +276,7 @@
 
         <div @click="deleteCourse()"
              class="button red hollow"
-             v-if="isTemplate || isForloebCompleted">
+             v-if="isTemplate || isUnderPreparation || isForloebCompleted">
                 Slet {{ isTemplate ? 'skabelon' : 'forløb' }}
         </div>
 
@@ -290,7 +298,7 @@
     </div>
 
     <div v-if="sortBy === 'deadline'">
-        <TaskList v-if="forloeb != null && isTemplate"
+        <TaskList v-if="forloeb != null && (isTemplate || isUnderPreparation)"
                 :tasks="opgaver_template"
                 :isFetchingTasks="!isOpgaverFetched"
                 :userInfo="userInfo"
@@ -300,7 +308,7 @@
                 :expandItem="expandItem"
                 :templateView="true" />
 
-        <TaskList v-if="(forloeb != null || userInfo.isAnsvarlig) && !isTemplate"
+        <TaskList v-if="(forloeb != null || userInfo.isAnsvarlig) && (!isTemplate && !isUnderPreparation)"
                 :tasks="opgaver_ongoing"
                 :isFetchingTasks="!isOpgaverFetched"
                 :userInfo="userInfo"
@@ -309,7 +317,7 @@
                 :expandFirstItem="false"
                 :expandItem="expandItem" />
 
-        <TaskList v-if="(forloeb != null || userInfo.isAnsvarlig) && !isTemplate"
+        <TaskList v-if="(forloeb != null || userInfo.isAnsvarlig) && (!isTemplate && !isUnderPreparation)"
                 :tasks="opgaver_future"
                 :isFetchingTasks="!isOpgaverFetched"
                 :userInfo="userInfo"
@@ -321,7 +329,7 @@
                 :forloebStartDate="new Date(forloeb?.startdate)"
                 :startMessageIndex="start_message_index" />
 
-        <TaskList v-if="(forloeb != null || userInfo.isAnsvarlig) && !isTemplate"
+        <TaskList v-if="(forloeb != null || userInfo.isAnsvarlig) && (!isTemplate && !isUnderPreparation)"
                 :tasks="opgaver_completed"
                 :isFetchingTasks="!isOpgaverFetched"
                 :userInfo="userInfo"

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -276,28 +276,22 @@
                 Afslut forløb
         </div>
 
-        <div @click="deleteCourse()"
-             class="button red hollow"
-             v-if="isTemplate || isForloebCompleted || (!isForloebCompleted && !isForloebOngoing)">
-                Slet {{ isTemplate ? 'skabelon' : 'forløb' }}
-        </div>
-
         <router-link :to="`/start-forloeb?id=${forloeb_id}`"
                      class="button hollow yellow"
                      v-if="!isTemplate && isUnderPreparation">
                         Start forløb
         </router-link>
 
+        <div @click="deleteCourse()"
+             class="button red hollow"
+             v-if="isTemplate || isForloebCompleted || (!isForloebCompleted && !isForloebOngoing)">
+                Slet {{ isTemplate ? 'skabelon' : 'forløb' }}
+        </div>
+
         <!-- <router-link :to="`/create-forloeb?tid=${forloeb_id}`"
                      class="button"
                      v-if="isTemplate">
                         + Opret forløb med skabelon
-        </router-link>
-
-        <router-link :to="`/create-forloeb?tid=${forloeb_id}&prep=true`"
-                     class="button yellow hollow"
-                     v-if="isTemplate">
-                        + Forbered forløb med skabelon
         </router-link> -->
 
     </div>

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -105,7 +105,6 @@
                     opgaver_response.data.sort((a, b) => new Date(a.slutdato) - new Date(b.slutdato))
 
                 opgaver_all.value = opgaver_response.data
-                opgaver_all.value.sort((a, b) => new Date(a.slutdato) - new Date(b.slutdato))
                 completedPercentage.value = opgaver_all.value.length > 0 ? Math.round(opgaver_all.value.filter(opgave => opgave.result).length / opgaver_all.value.length * 100) : 0
 
                 if(props.isTemplate || isUnderPreparation.value)
@@ -113,10 +112,9 @@
                     opgaver_template.value = opgaver_response.data
                     // Get first index of all tasks that start after forløb start date
                     start_message_index.value = opgaver_template.value
-                        .map(opgave => opgave.relativ_startdag > 0)
+                        .map(opgave => opgave.relativ_startdag > -1)
                         .findIndex(opgave => opgave)
                 }
-                    
                 else
                 {
                     for (const item of opgaver_response.data) {
@@ -295,7 +293,7 @@
         <div style="flex-grow:1">&nbsp;</div>
         <div class="sort-title">Sortér efter:</div>
         <select class="sort-selector" v-model="sortBy">
-            <option value="deadline">Deadline</option>
+            <option value="deadline">{{ isUnderPreparation || isTemplate ? 'Startdag' : 'Deadline' }}</option>
             <option value="gruppe">Gruppe</option>
         </select>
     </div>

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -259,9 +259,14 @@
                         + Tilføj opgave
         </router-link>
 
-        <router-link :to="`/create-forloeb${isTemplate ? 'sskabelon':''}?edit=true&id=${forloeb_id}&prep=${isUnderPreparation}`"
+        <router-link :to="`/edit-forloeb?id=${forloeb_id}`" v-if="!isTemplate"
                      class="button hollow">
-                        Redigér {{isForloebCompleted ? ' / genoptag ' : '' }}{{ isTemplate ? 'skabelon' : 'forløb' }}
+                        Redigér{{isForloebCompleted ? ' / genoptag' : '' }} forløb
+        </router-link>
+
+        <router-link :to="`/create-forloebsskabelon?id=${forloeb_id}&edit=true`" v-else
+                     class="button hollow">
+                        Redigér skabelon
         </router-link>
 
         <div @click="downloadForloeb()"

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -68,7 +68,6 @@
                                         : props.isTemplate ? await getForloebsskabelonById(props.id)
                                         // Otherwise fetch by id and user email (for admins and ansvarlig users)
                                         : await getForloebById(props.id, { headers })
-
                 isForloebFetched.value = true
                 forloeb.value = forloeb_response?.data
                 isUnderPreparation.value = forloeb.value?.isPreparation || false
@@ -110,7 +109,14 @@
                 completedPercentage.value = opgaver_all.value.length > 0 ? Math.round(opgaver_all.value.filter(opgave => opgave.result).length / opgaver_all.value.length * 100) : 0
 
                 if(props.isTemplate || isUnderPreparation.value)
+                {
                     opgaver_template.value = opgaver_response.data
+                    // Get first index of all tasks that start after forløb start date
+                    start_message_index.value = opgaver_template.value
+                        .map(opgave => opgave.relativ_startdag > 0)
+                        .findIndex(opgave => opgave)
+                }
+                    
                 else
                 {
                     for (const item of opgaver_response.data) {
@@ -122,13 +128,11 @@
                         else 
                             opgaver_ongoing.value.push(item)
                     }
-
-                    // Get last index of future tasks that start after forløb start date
+                    // Get first index of future tasks that start after forløb start date
                     opgaver_future.value.sort((a, b) => new Date(a.startdato) - new Date(b.startdato))
                     start_message_index.value = opgaver_future.value
                         .map(opgave => new Date(opgave.startdato) > new Date(forloeb.value.startdate))
-                        .lastIndexOf(true)
-                    console.log('Start message index:', start_message_index.value)
+                        .findIndex(opgave => opgave)
                 }
 
                 isOpgaverFetched.value = true
@@ -226,7 +230,6 @@
     <p v-if="showDetails" class="indent-tiny bold uppercase p-header-adjust">
         Oversigt
     </p>
-    {{ forloeb }}
     <CourseItem v-if="forloeb != null && isOpgaverFetched && showDetails"
                 :disableInteraction="true" 
                 :dark="true" 
@@ -246,7 +249,7 @@
     <!-- Admin actions -->
     <div class="buttons" v-if="userInfo.isAdmin && !props.ansvarligView && forloeb != null && isOpgaverFetched">
 
-        <router-link :to="`/create-opgave?id=${forloeb_id}`"
+        <router-link :to="`/create-opgave?id=${forloeb_id}&prep=${isUnderPreparation}`"
                      class="button" v-if="!isTemplate && !isForloebCompleted">
                         + Tilføj opgave
         </router-link>
@@ -296,7 +299,6 @@
             <option value="gruppe">Gruppe</option>
         </select>
     </div>
-
     <div v-if="sortBy === 'deadline'">
         <TaskList v-if="forloeb != null && (isTemplate || isUnderPreparation)"
                 :tasks="opgaver_template"
@@ -306,7 +308,10 @@
                 :largeHeaderAdjust="true"
                 :expandFirstItem="false"
                 :expandItem="expandItem"
-                :templateView="true" />
+                :templateView="isTemplate"
+                :isPreparation="isUnderPreparation"
+                :forloebStartDate="new Date(forloeb?.startdate)"
+                :startMessageIndex="start_message_index" />
 
         <TaskList v-if="(forloeb != null || userInfo.isAnsvarlig) && (!isTemplate && !isUnderPreparation)"
                 :tasks="opgaver_ongoing"
@@ -348,7 +353,9 @@
                 :title="group.name"
                 :largeHeaderAdjust="true"
                 :expandFirstItem="false"
-                :expandItem="expandItem" />
+                :expandItem="expandItem"
+                :templateView="isTemplate"
+                :isPreparation="isUnderPreparation" />
 
         
         <TaskList v-if="forloeb != null"
@@ -358,7 +365,9 @@
                 title="Ingen gruppe"
                 :largeHeaderAdjust="true"
                 :expandFirstItem="false"
-                :expandItem="expandItem" />
+                :expandItem="expandItem"
+                :templateView="isTemplate"
+                :isPreparation="isUnderPreparation" />
     </div>
 
 </template>

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -265,7 +265,7 @@
 
         <div @click="downloadForloeb()"
              class="button hollow dashed"
-             v-if="!isTemplate">
+             v-if="!isTemplate && !isUnderPreparation">
                 Download PDF
         </div>
 
@@ -277,14 +277,26 @@
 
         <div @click="deleteCourse()"
              class="button red hollow"
-             v-if="isTemplate || isUnderPreparation || isForloebCompleted">
+             v-if="isTemplate || isForloebCompleted || (!isForloebCompleted && !isForloebOngoing)">
                 Slet {{ isTemplate ? 'skabelon' : 'forløb' }}
         </div>
+
+        <router-link :to="`/start-forloeb?id=${forloeb_id}`"
+                     class="button hollow yellow"
+                     v-if="!isTemplate && isUnderPreparation">
+                        Start forløb
+        </router-link>
 
         <router-link :to="`/create-forloeb?tid=${forloeb_id}`"
                      class="button"
                      v-if="isTemplate">
                         + Opret forløb med skabelon
+        </router-link>
+
+        <router-link :to="`/create-forloeb?tid=${forloeb_id}&prep=true`"
+                     class="button yellow hollow"
+                     v-if="isTemplate">
+                        + Forbered forløb med skabelon
         </router-link>
 
     </div>

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -75,8 +75,8 @@
                 isForloebOngoing.value = !isUnderPreparation.value && forloeb.value?.startdate ? new Date(forloeb.value.startdate) <= new Date() : false
                 forloeb_id.value = forloeb.value?.ForløbID || forloeb.value?.ForløbsskabelonID
                 userTitle.value = forloeb.value?.userdq != '' ? forloeb.value?.userdq : forloeb.value?.usermail
-                if (forloeb.value.opgave_grupper && Array.isArray(forloeb.value.opgave_grupper))
-                    forloeb.value.opgave_grupper.sort((a, b) => a.name.localeCompare(b.name))
+                if (forloeb.value?.opgave_grupper && Array.isArray(forloeb.value.opgave_grupper))
+                    forloeb.value?.opgave_grupper.sort((a, b) => a.name.localeCompare(b.name))
                 
                 // Get opgaver
                                         // As ansvarlig fetch opgaver
@@ -128,9 +128,10 @@
                     }
                     // Get first index of future tasks that start after forløb start date
                     opgaver_future.value.sort((a, b) => new Date(a.startdato) - new Date(b.startdato))
-                    start_message_index.value = opgaver_future.value
-                        .map(opgave => new Date(opgave.startdato) > new Date(forloeb.value.startdate))
-                        .findIndex(opgave => opgave)
+                    if (forloeb.value?.startdate)
+                        start_message_index.value = opgaver_future.value
+                            .map(opgave => new Date(opgave.startdato) > new Date(forloeb.value.startdate))
+                            .findIndex(opgave => opgave)
                 }
 
                 isOpgaverFetched.value = true
@@ -301,7 +302,7 @@
 
     </div>
 
-    <div v-if="forloeb != null && forloeb?.opgave_grupper.length > 0" class="sort-container">
+    <div v-if="forloeb != null && forloeb?.opgave_grupper?.length > 0" class="sort-container">
         <div style="flex-grow:1">&nbsp;</div>
         <div class="sort-title">Sortér efter:</div>
         <select class="sort-selector" v-model="sortBy">

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -240,7 +240,8 @@
                 :startDate="new Date(forloeb.startdate)" 
                 :deadline="new Date(forloeb.enddate)"
                 :tasks="opgaver_all"
-                :isPreparation="isUnderPreparation" />
+                :isPreparation="isUnderPreparation"
+                :mails="forloeb.pending_emails" />
 
     <Placeholder v-if="!isOpgaverFetched && showDetails" :height="isTemplate || isUnderPreparation ? 4.5 : 7.2" :dark="true" />
     <ProgressBar v-if="forloeb != null  && !showDetails && !isUnderPreparation" :percentage="completedPercentage"></ProgressBar>

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -128,7 +128,7 @@
                     }
                     // Get first index of future tasks that start after forløb start date
                     opgaver_future.value.sort((a, b) => new Date(a.startdato) - new Date(b.startdato))
-                    if (forloeb.value?.startdate)
+                    if (!isForloebOngoing.value && forloeb.value?.startdate)
                         start_message_index.value = opgaver_future.value
                             .map(opgave => new Date(opgave.startdato) > new Date(forloeb.value.startdate))
                             .findIndex(opgave => opgave)
@@ -288,7 +288,7 @@
                         Start forløb
         </router-link>
 
-        <router-link :to="`/create-forloeb?tid=${forloeb_id}`"
+        <!-- <router-link :to="`/create-forloeb?tid=${forloeb_id}`"
                      class="button"
                      v-if="isTemplate">
                         + Opret forløb med skabelon
@@ -298,7 +298,7 @@
                      class="button yellow hollow"
                      v-if="isTemplate">
                         + Forbered forløb med skabelon
-        </router-link>
+        </router-link> -->
 
     </div>
 

--- a/vue/src/components/Navbar.vue
+++ b/vue/src/components/Navbar.vue
@@ -1,14 +1,11 @@
 <script setup>
-    import { ref, onMounted, watch } from 'vue'
-    import { useRoute } from 'vue-router'
-
+    import { ref, onMounted } from 'vue'
     import { getUserInfo } from '@/services/keycloakService.js'
 
     const adminMenuItems = [
         {
             "title": "Overblik",
             "url": "/admin-overview",
-            "alias": ['/forloeb-overview'],
             "icon": "fa-solid fa-list-check"
         },
         {
@@ -66,28 +63,9 @@
                 menuItems.value = defaultMenuItems
             }
 
-            // Set selected = true for landing page (URL)
-            const landingPageIndex = menuItems.value.findIndex(x => x.url == new URL(location.href).pathname)
-            if (landingPageIndex !== -1)
-                menuItems.value[landingPageIndex].selected = true
         }).catch(error => {
             console.error('Error fetching user info:', error);
         });
-    })
-
-    function select(item) {
-        menuItems.value.forEach(x => x.selected = false)
-        item.selected = true
-    }
-
-    const route = useRoute()
-
-    watch(() => route.path, (newPath) => {
-        const matchFound = menuItems.value.some(item => item.url === newPath) || menuItems.value.some(item => item.alias?.includes(newPath))
-        if (!matchFound) return
-        menuItems.value.forEach(item => {
-            item.selected = item.url === newPath || item.alias?.includes(newPath)
-        })
     })
 </script>
 
@@ -95,7 +73,7 @@
 
     <div class="navbar">
 
-        <router-link v-for="item in menuItems" :key="item.title" class="item" :class="{ selected: item.selected }" :to="item.url" @click="select(item)">
+        <router-link v-for="item in menuItems" :key="item.title" class="item" :to="item.url">
             <i :class="item.icon + ' fa-xl'"></i>
             <span>{{ item.title }}</span>
         </router-link>

--- a/vue/src/components/TaskItem.vue
+++ b/vue/src/components/TaskItem.vue
@@ -282,13 +282,17 @@
                 <div class="tooltipContainer">
                     <div class="icon"><i class="fa-solid fa-envelope"></i></div>
                     <div class="text">
-                    <div class="small faded">Mails</div>
-                    <div>{{ dynamicMails.length > 0 ? (dynamicMails.length + ' afventer') : 'Ingen mails' }}</div>
+                        <div class="small faded">Mails</div>
+                        <div>{{ dynamicMails.length > 0 ? (dynamicMails.length + ' planlagt') : 'Ingen mails' }}</div>
                     </div>
                     
                     <div class="tooltip">
-                        <div class="mail" v-for="mail in dynamicMails" :key="mail.id" @click="deletePendingEmail(mail.id)">
-                            {{ mail.subject }} ({{ mail.recipient }}) <i class="fa-solid fa-xmark"></i>
+                        <div class="mail" v-for="mail in dynamicMails" :key="mail.id">
+                            <div>
+                                <div class="nowrap">Notifikation til ansvarlig</div>
+                                <div class="mail-recipient nowrap">{{ mail.recipient }}</div>
+                            </div>
+                            <i @click="deletePendingEmail(mail.id)" class="fa-solid fa-circle-xmark"></i>
                         </div>
                     </div>
                 </div>
@@ -434,17 +438,38 @@
         right: -0.75rem;
 
         font-size: 0.75rem;
-        white-space: nowrap;
         cursor: default;
         text-align: right;
 
         max-height: 4rem;
         overflow-y: auto;
+        user-select: text;
+
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.4rem;
     }
-        .tooltip > .mail:has(i):hover {
-            color: var(--color-button-red);
-            cursor: pointer;
-        }
+    .tooltip > .mail {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+    .mail-recipient {
+        max-width: 15rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.9em;
+        font-weight: 400;
+    }
+    .tooltip i {
+        margin-left: 0.5rem;
+        font-size: 1rem;
+    }
+    .tooltip i:hover {
+        color: var(--color-button-red);
+        cursor: pointer;
+    }
     .tooltipContainer:hover > .tooltip {
         visibility: visible;
         opacity: 1;

--- a/vue/src/components/TaskItem.vue
+++ b/vue/src/components/TaskItem.vue
@@ -153,6 +153,11 @@
         mails: {
             type: Array,
             default: []
+        },
+        isPreparation:
+        {
+            type: Boolean,
+            default: false
         }
     })
 
@@ -221,11 +226,9 @@
     const gotoTask = () => {
         const currentQuery = router.currentRoute.value.query
         let updateQuery = { ...currentQuery, item: props.id }
-        // if (props.isTemplate) 
-        //     updateQuery.template = true
 
         router.replace({ query: updateQuery }).then(() => {
-            router.push({ path: '/create-opgave', query: { id: props.id, edit: true, template: props.isTemplate } })
+            router.push({ path: '/create-opgave', query: { id: props.id, edit: true, template: props.isTemplate, prep: props.isPreparation } })
         })
     }
 
@@ -304,7 +307,7 @@
 
         <div class="card-content">
             <div class="card-details">
-                <div v-if="templateView && !isTemplate">
+                <div v-if="(templateView && !isTemplate) || isPreparation">
                     <div class="icon"><i class="fa-solid fa-clock"></i></div>
                     <div class="text">
                         <div class="small faded">Startdag</div>
@@ -315,8 +318,8 @@
                 <div>
                     <div class="icon"><i class="fa-solid fa-clock"></i></div>
                     <div class="text">
-                        <div class="small faded">{{ templateView ? 'Varighed' : isFutureTask ? 'Starter om' : 'Deadline' }}</div>
-                        <div>{{ templateView ? relativeEnddate + ' ' + returnDagOrDage(relativeEnddate) : returnTimeLeft(isFutureTask ? startdate : deadline) }}</div>
+                        <div class="small faded">{{ templateView || isPreparation ? 'Varighed' : isFutureTask ? 'Starter om' : 'Deadline' }}</div>
+                        <div>{{ templateView || isPreparation ? relativeEnddate + ' ' + returnDagOrDage(relativeEnddate) : returnTimeLeft(isFutureTask ? startdate : deadline) }}</div>
                     </div>
                 </div>
 
@@ -333,7 +336,7 @@
                     </div>
                 </div>
 
-                <div v-if="!templateView">
+                <div v-if="!templateView && !isPreparation">
                     <div class="icon"><i class="fa-solid fa-calendar"></i></div>
                     <div class="text">
                         <div class="small faded">Booking</div>
@@ -382,7 +385,7 @@
                 </div>
 
                 <div :class="['button', 'hollow', {'red': result}]"
-                     v-if="!templateView && 
+                     v-if="!templateView && !isPreparation && 
                             (userInfo?.isAdmin ||
                                 (userInfo?.isAnsvarlig && userInfo?.email == ansvarligEmail) ||
                                 (userInfo?.isMedarbejder && ansvarligEmail == '')

--- a/vue/src/components/TaskItem.vue
+++ b/vue/src/components/TaskItem.vue
@@ -384,7 +384,7 @@
                         Redigér
                 </div>
 
-                <div :class="['button', 'hollow', {'red': result}]"
+                <div :class="['button', 'hollow', {'yellow': result}]"
                      v-if="!templateView && !isPreparation && 
                             (userInfo?.isAdmin ||
                                 (userInfo?.isAnsvarlig && userInfo?.email == ansvarligEmail) ||

--- a/vue/src/components/TaskItem.vue
+++ b/vue/src/components/TaskItem.vue
@@ -289,7 +289,7 @@
                     <div class="tooltip">
                         <div class="mail" v-for="mail in dynamicMails" :key="mail.id">
                             <div>
-                                <div class="nowrap">Notifikation til ansvarlig</div>
+                                <div class="nowrap">Notifikation</div>
                                 <div class="mail-recipient nowrap">{{ mail.recipient }}</div>
                             </div>
                             <i @click="deletePendingEmail(mail.id)" class="fa-solid fa-circle-xmark"></i>

--- a/vue/src/components/TaskItem.vue
+++ b/vue/src/components/TaskItem.vue
@@ -148,11 +148,11 @@
         ressources:
         {
             type: Array,
-            default: []
+            default: () => []
         },
         mails: {
             type: Array,
-            default: []
+            default: () => []
         },
         isPreparation:
         {

--- a/vue/src/components/TaskList.vue
+++ b/vue/src/components/TaskList.vue
@@ -63,6 +63,11 @@
         {
             type: Number,
             default: -1
+        },
+        isPreparation:
+        {
+            type: Boolean,
+            default: false
         }
     })
 
@@ -95,15 +100,16 @@
                     :ansvarlig="task.ansvarlig"
                     :ansvarligEmail="task.ansvarligEmail"
                     :booking="task.booking ? new Date(new Date(task.booking)) : null"
-                    :color="props.itemColor != null ? props.itemColor : task.result ? '617a5d' : (!templateView && new Date(task.slutdato) < new Date()) ? 'bf4e4e' : defaultItemColor"
-                    :border="(!task.result && !templateView && new Date(task.slutdato) < new Date()) ? 'bf4e4e' : null"
+                    :color="props.itemColor != null ? props.itemColor : task.result ? '617a5d' : (!templateView && !isPreparation && new Date(task.slutdato) < new Date()) ? 'bf4e4e' : defaultItemColor"
+                    :border="(!task.result && !templateView && !isPreparation && new Date(task.slutdato) < new Date()) ? 'bf4e4e' : null"
                     :expandByDefault="expandFirstItem && index == 0 || expandItem === task.OpgaveID || expandItem === task.OpgaveskabelonID"
                     :dark="dark || task.result"
                     :templateView="templateView"
                     :isTemplate="task.OpgaveskabelonID != null"
                     :result="task.result"
                     :ressources="task.resourcer"
-                    :mails="task.pending_emails" />
+                    :mails="task.pending_emails"
+                    :isPreparation="isPreparation" />
             </template>
         </div><!-- /card-list -->
         <div v-else>

--- a/vue/src/components/TaskList.vue
+++ b/vue/src/components/TaskList.vue
@@ -119,7 +119,7 @@
         </div><!-- /card-list -->
         <div v-else>
             <p class="indent-tiny" v-if="isFetchingTasks">Indlæser ...</p>
-            <p class="indent-tiny" v-else>Ingen opgaver fundet.</p>
+            <p class="indent-tiny faded" v-else>Ingen opgaver fundet.</p>
         </div>
     </div>
 

--- a/vue/src/components/TaskList.vue
+++ b/vue/src/components/TaskList.vue
@@ -83,7 +83,7 @@
                     <div class="line"></div>
                     <span class="text">Forløbet starter
                         {{
-                            isPreparation ? 'her' :
+                            isPreparation || templateView ? 'her' :
                             new Date(forloebStartDate).toLocaleDateString('da-DK', { year: 'numeric', month: '2-digit', day: '2-digit' })
                         }}
                     </span>

--- a/vue/src/components/TaskList.vue
+++ b/vue/src/components/TaskList.vue
@@ -81,7 +81,12 @@
             <template v-for="(task, index) in tasks">
                 <div class="start-spacer" v-if="forloebStartDate != null && index === startMessageIndex">
                     <div class="line"></div>
-                    <span class="text">Forløbet starter {{ new Date(forloebStartDate).toLocaleDateString('da-DK', { year: 'numeric', month: '2-digit', day: '2-digit' }) }}</span>
+                    <span class="text">Forløbet starter
+                        {{
+                            isPreparation ? 'her' :
+                            new Date(forloebStartDate).toLocaleDateString('da-DK', { year: 'numeric', month: '2-digit', day: '2-digit' })
+                        }}
+                    </span>
                 </div>
                 <Card
                     :userInfo="userInfo"
@@ -124,7 +129,6 @@
     font-size: 0.8em;
     text-transform: none;
     width: 100%;
-    max-width: 38rem;
     text-align: center;
     position: relative;
 }
@@ -134,8 +138,12 @@
         position: absolute;
         top: 50%;
         width: 100%;
-        max-width: 38rem;
         z-index: 1;
+    }
+    @media only screen and (min-width: 768px) {
+        .start-spacer, .start-spacer > .line {
+            max-width: 38rem;
+        }
     }
     .start-spacer > .text {
         background-color: var(--color-background);

--- a/vue/src/main.js
+++ b/vue/src/main.js
@@ -10,6 +10,7 @@ import { getUserInfo } from './services/keycloakService.js'
 // Import af views til routing
 import CreateOpgave from '@/views/admin/CreateOpgave.vue'
 import CreateForløb from '@/views/admin/CreateForløb.vue'
+import StartForløb from '@/views/admin/StartForløb.vue'
 import CreateRessource from '@/views/admin/CreateRessource.vue'
 import CreateForløbsskabelon from '@/views/admin/CreateForløbsskabelon.vue'
 import AdminOverview from '@/views/admin/AdminOverview.vue'
@@ -35,6 +36,12 @@ const routes = [
         path: '/create-forloeb',
         name: 'CreateForløb',
         component: CreateForløb,
+        meta: { roles: ['Admin'] }
+    },
+    {
+        path: '/start-forloeb',
+        name: 'StartForløb',
+        component: StartForløb,
         meta: { roles: ['Admin'] }
     },
     {

--- a/vue/src/main.js
+++ b/vue/src/main.js
@@ -10,6 +10,7 @@ import { getUserInfo } from './services/keycloakService.js'
 // Import af views til routing
 import CreateOpgave from '@/views/admin/CreateOpgave.vue'
 import CreateForløb from '@/views/admin/CreateForløb.vue'
+import EditForløb from '@/views/admin/EditForløb.vue'
 import StartForløb from '@/views/admin/StartForløb.vue'
 import CreateRessource from '@/views/admin/CreateRessource.vue'
 import CreateForløbsskabelon from '@/views/admin/CreateForløbsskabelon.vue'
@@ -36,6 +37,12 @@ const routes = [
         path: '/create-forloeb',
         name: 'CreateForløb',
         component: CreateForløb,
+        meta: { roles: ['Admin'] }
+    },
+    {
+        path: '/edit-forloeb',
+        name: 'EditForløb',
+        component: EditForløb,
         meta: { roles: ['Admin'] }
     },
     {

--- a/vue/src/services/forløbService.js
+++ b/vue/src/services/forløbService.js
@@ -6,6 +6,10 @@ export const createForloeb = (data) => {
   return axios.post(`${API_URL}/forloeb`, data);
 };
 
+export const startForloeb = (data) => {
+  return axios.post(`${API_URL}/forloeb-start`, data);
+};
+
 export const createForloebPreparation = (data) => {
   return axios.post(`${API_URL}/forloeb-preparation`, data);
 };

--- a/vue/src/services/forløbService.js
+++ b/vue/src/services/forløbService.js
@@ -6,6 +6,10 @@ export const createForloeb = (data) => {
   return axios.post(`${API_URL}/forloeb`, data);
 };
 
+export const createForloebPreparation = (data) => {
+  return axios.post(`${API_URL}/forloeb-preparation`, data);
+};
+
 export const getForloebByAdmin = (config) => {
   return axios.get(`${API_URL}/forloeb`, config);
 };

--- a/vue/src/views/admin/AdminOverview.vue
+++ b/vue/src/views/admin/AdminOverview.vue
@@ -8,6 +8,7 @@
 	const forloeb_ongoing = ref([])
 	const forloeb_future = ref([])
 	const forloeb_completed = ref([])
+	const forloeb_preparation = ref([])
 
 	onMounted( () => {	
 		getUserInfo().then(userInfo => {
@@ -27,6 +28,9 @@
 						response.data = [response.data]
 
 					for (const item of response.data) {
+						if (item.isPreparation)
+							forloeb_preparation.value.push(item)
+						else
 						if (new Date(item.startdate) > new Date())
 							forloeb_future.value.push(item)
 						else
@@ -48,7 +52,8 @@
 </script>
 
 <template>
-  <CourseList :courses="forloeb_ongoing" />
+  <CourseList :courses="forloeb_preparation" title="Under forberedelse" v-if="forloeb_preparation.length > 0" />
+  <CourseList :courses="forloeb_ongoing" :largeHeaderAdjust="forloeb_preparation.length > 0" />
   <CourseList :courses="forloeb_future" title="Kommende forløb" :largeHeaderAdjust="true" />
   <CourseList :courses="forloeb_completed" title="Afsluttede forløb" :largeHeaderAdjust="true" :dark="true" />
 </template>

--- a/vue/src/views/admin/CreateForløb.vue
+++ b/vue/src/views/admin/CreateForløb.vue
@@ -13,7 +13,7 @@
     const isSubmitting = ref(false)
     const isEditing = route.query.edit === 'true'
     const forloeb_id = isEditing ? parseInt(route.query.id, 10) : null
-    const isPreparation = route.query.prep == 'true'
+    const isPreparation = route.query.prep !== 'false'
 
 	const template_id = parseInt(route.query.tid, 10)
     const templates = ref([])
@@ -143,7 +143,7 @@
     }
     
     const selectNoTemplateIfNotSelected = () => {
-        if(inputFields.value.ForløbsskabelonID == "" && !isPreparation)
+        if(inputFields.value.ForløbsskabelonID == "")
             inputFields.value.ForløbsskabelonID = null
     }
 
@@ -292,14 +292,14 @@
         <div v-if="!isEditing" :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]">
             <select id="template" name="template" v-model="inputFields.ForløbsskabelonID" required>
                 <option value="" disabled selected hidden></option>
-                <option :value="null" v-if="!isPreparation">Ingen skabelon</option>
+                <option :value="null">Ingen skabelon</option>
                 <option v-for="template in templates" :value="template.ForløbsskabelonID">{{template.name}}</option>
             </select>
             <label for="template" class="floating-label">Skabelon</label>
             <div class="icon nohover"><i class="fa-solid fa-caret-down"></i></div>
         </div>
         
-        <div v-if="!isPreparation" :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]">
+        <div v-if="!isPreparation && isEditing" :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]">
             <div class="flex-item">
                 <input type="date" id="startdate" name="startdate" v-model="inputFields.startdate" @input="setEndDateFromTemplate()" required>
                 <label for="startdate" class="floating-label">Startdato</label>

--- a/vue/src/views/admin/CreateForløb.vue
+++ b/vue/src/views/admin/CreateForløb.vue
@@ -4,7 +4,7 @@
 
     import { getUserInfo } from '@/services/keycloakService.js'
     import { getForloebsskabeloner } from '@/services/forløbsskabelonService.js'
-    import { createForloeb, getForloebById, updateForloeb } from '@/services/forløbService.js'
+    import { createForloeb, createForloebPreparation, getForloebById, updateForloeb } from '@/services/forløbService.js'
     import { getAdminData, getUsers } from '@/services/userService.js'
 
     const route = useRoute()
@@ -13,6 +13,7 @@
     const isSubmitting = ref(false)
     const isEditing = route.query.edit === 'true'
     const forloeb_id = isEditing ? parseInt(route.query.id, 10) : null
+    const isPreparation = route.query.prep == 'true'
 
 	const template_id = parseInt(route.query.tid, 10)
     const templates = ref([])
@@ -142,7 +143,7 @@
     }
     
     const selectNoTemplateIfNotSelected = () => {
-        if(inputFields.value.ForløbsskabelonID == "")
+        if(inputFields.value.ForløbsskabelonID == "" && !isPreparation)
             inputFields.value.ForløbsskabelonID = null
     }
 
@@ -235,8 +236,12 @@
             // }
             // else 
             //     delete formData.privateEmail
-
-            const response = isEditing ? await updateForloeb(forloeb_id, formData) : await createForloeb(formData)
+            console.log(formData)
+            const response = isEditing ?
+                                await updateForloeb(forloeb_id, formData)
+                            : isPreparation ?
+                                await createForloebPreparation(formData)
+                            : await createForloeb(formData)
             if(response.data.uid)
                 router.push({ path: '/forloeb-overview', query: { id: response.data.uid } })
             
@@ -251,7 +256,7 @@
 </script>
 
 <template>
-    <p class="indent-tiny bold uppercase p-header-adjust">{{ isEditing ? 'Rediger forløb' : 'Opret forløb' }}</p>
+    <p class="indent-tiny bold uppercase p-header-adjust">{{ isEditing ? 'Rediger forløb' : (isPreparation ? 'Opret forløbsforberedelse' : 'Opret forløb') }}</p>
 
     <form @submit.prevent="submitForm">
     <div class="formContainer">
@@ -287,14 +292,14 @@
         <div v-if="!isEditing" :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]">
             <select id="template" name="template" v-model="inputFields.ForløbsskabelonID" required>
                 <option value="" disabled selected hidden></option>
-                <option :value="null">Ingen skabelon</option>
+                <option :value="null" v-if="!isPreparation">Ingen skabelon</option>
                 <option v-for="template in templates" :value="template.ForløbsskabelonID">{{template.name}}</option>
             </select>
             <label for="template" class="floating-label">Skabelon</label>
             <div class="icon nohover"><i class="fa-solid fa-caret-down"></i></div>
         </div>
         
-        <div :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]">
+        <div v-if="!isPreparation" :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]">
             <div class="flex-item">
                 <input type="date" id="startdate" name="startdate" v-model="inputFields.startdate" @input="setEndDateFromTemplate()" required>
                 <label for="startdate" class="floating-label">Startdato</label>

--- a/vue/src/views/admin/CreateForløb.vue
+++ b/vue/src/views/admin/CreateForløb.vue
@@ -203,7 +203,6 @@
             formData.admin = selectedAdmin.value.mail
             if (!formData.ForløbsskabelonID)
                 delete formData.ForløbsskabelonID
-            console.log(formData)
             const response = isPreparation ?
                 await createForloebPreparation(formData)
                 : await createForloeb(formData)

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -328,6 +328,7 @@
 </script>
 
 <template>
+    Er template: {{ isTemplate }}
     <p class="indent-tiny bold uppercase p-header-adjust">
         {{ isEditing ? 'Rediger opgave' : isTemplate ? 'Opret opgaveskabelon' : 'Tilføj opgave til' }}
         {{ isTemplate ? '' : ' på ' + forloeb?.name?? 'forløbet' }}

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -352,7 +352,7 @@
 <template>
     <p class="indent-tiny bold uppercase p-header-adjust">
         {{ isEditing ? 'Rediger opgave' : isTemplate ? 'Opret opgaveskabelon' : 'Tilføj opgave' }}
-        {{ isTemplate ? '' : ' til ' + forloeb?.name?? 'forløbet' }}
+        {{ isTemplate ? '' : ' til ' + (forloeb?.name ?? 'forløbet') }}
     </p>
 
     <form @submit.prevent="submitForm">
@@ -384,7 +384,7 @@
                     <span class="tooltip-display nohover">Vælg skabelon</span>
                 </div>
             </div>
-            
+
             <div class="inputContainer" v-if="!isTemplate && !addToTemplate">
                 <input type="text" id="assistant" name="assistant" placeholder=" " @input="searchAssistants(inputFields.ansvarlig)" v-model="inputFields.ansvarlig" class="locked" :disabled="isAssistantLocked">
                 <label for="assistant" class="floating-label">Ansvarlig medarbejder</label>
@@ -434,7 +434,7 @@
                 </div>
             </div>
 
-            
+
             <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate && !isPreparation">
                 <input type="datetime-local" id="booking" name="booking" v-model="inputFields.booking">
                 <label for="booking" class="floating-label">Booking</label>

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -277,7 +277,7 @@
 
     const removeNonIntegers = (value) => {
         // Allow a single minus at the start, then digits only
-        return value.replace(/(?!^-\d*)[^\d-]|(?!^)-/g, '').replace(/(?!^)-/g, '')
+        return value.replace(/[^-\d]/g, '').replace(/(?!^)-/g, '')
     }
 
     const sliceXChars = (value, x) => {

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -15,6 +15,7 @@
     const forloeb_id = ref(parseInt(route.query.id ?? route.query.tid, 10))
     const isTemplate = route.query.template === 'true'  // Whether we are adding an opgave to a forløb/forløbsskablon or creating a template
     const addToTemplate = ref(route.query.tid != null) // Whether we are adding an opgave to a forløbsskabelon
+    const isPreparation = ref(!isTemplate && route.query.prep === 'true') // Whether the forløb is under preparation (only relevant if not a template)
     const isSubmitting = ref(false)
     const isEditing = route.query.edit === 'true'
     const opgaveId = isEditing ? parseInt(route.query.id, 10) : null
@@ -123,7 +124,7 @@
         inputFields.value.startdato = template.startdato
         inputFields.value.slutdato = template.slutdato
         inputFields.value.booking = template.booking
-        if(addToTemplate)
+        if(addToTemplate.value || isPreparation.value)
         {
             inputFields.value.relativ_slutdag = template.relativ_slutdag
             relativEndday.value = inputFields.value.relativ_slutdag
@@ -136,7 +137,7 @@
     }
 
     const setEndDateFromTemplate = () => {
-        if (selectedTemplate.value) {
+        if (selectedTemplate.value && !isPreparation.value) {
             const startDate = new Date(inputFields.value.startdato)
             const daysToAdd = selectedTemplate.value.relativ_slutdag
             var endDate = new Date(startDate)
@@ -283,7 +284,7 @@
                 ...inputFields.value
             }
 
-            if(isTemplate || addToTemplate.value)
+            if(isTemplate || addToTemplate.value || isPreparation.value)
                 delete formData.startdato, delete formData.slutdato, delete formData.booking
             else
                 delete formData.relativ_startdag, delete formData.relativ_slutdag
@@ -329,7 +330,8 @@
 <template>
     <p class="indent-tiny bold uppercase p-header-adjust">
         {{ isEditing ? 'Rediger opgave' : isTemplate ? 'Opret opgaveskabelon' : 'Tilføj opgave til' }}
-        {{ isTemplate ? '' : ' på ' + forloeb?.name?? 'forløbet' }}</p>
+        {{ isTemplate ? '' : ' på ' + forloeb?.name?? 'forløbet' }}
+    </p>
 
     <form @submit.prevent="submitForm">
     <div class="formContainer">
@@ -386,7 +388,7 @@
             </div>
         </div>
 
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate">
+        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate && !isPreparation">
             <div class="flex-item">
                 <input type="date" id="startdate" name="startdate" v-model="inputFields.startdato" @change="setEndDateFromTemplate()" required>
                 <label for="startdate" class="floating-label">Startdato</label>
@@ -398,14 +400,14 @@
         </div>
 
         
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate">
+        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate && !isPreparation">
             <input type="datetime-local" id="booking" name="booking" v-model="inputFields.booking">
             <label for="booking" class="floating-label">Booking</label>
         </div>
 
         <!--  Relative start and end days -->
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="isTemplate || addToTemplate">
-            <div v-if="addToTemplate" class="flex-item">
+        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="isTemplate || addToTemplate || isPreparation">
+            <div v-if="addToTemplate || isPreparation" class="flex-item">
                 <input type="text" id="startdate" class="padding-input" name="startdate"
                         v-model="inputFields.relativ_startdag" ref="relativStartday"
                         @input="relativStartday.value=sliceXChars(removeNonIntegers(relativStartday.value), 3)"

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -89,7 +89,7 @@
     }
 
     const returnDagOrDage = (days) => {
-        return days > 1 || days == 0 ? 'dage' : 'dag'
+        return days == 1 || days == -1 ? 'dag' : 'dage'
     }
 
     /* Textarea */
@@ -255,7 +255,8 @@
     /* Submit */
 
     const removeNonIntegers = (value) => {
-        return value.replace(/(?![0-9])./gmi,'')
+        // Allow a single minus at the start, then digits only
+        return value.replace(/(?!^-\d*)[^\d-]|(?!^)-/g, '').replace(/(?!^)-/g, '')
     }
 
     const sliceXChars = (value, x) => {

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -127,9 +127,10 @@
             inputFields.value.booking = ""
             if(addToTemplate.value || isPreparation.value)
             {
-                inputFields.value.relativ_slutdag = template.relativ_slutdag
+                inputFields.value.relativ_slutdag = 1
                 relativEndday.value = inputFields.value.relativ_slutdag
             }
+            return
         }
         
         inputFields.value.title = template.title
@@ -378,7 +379,7 @@
             <div class="inputContainer">
                 <input type="text" id="title" name="title" placeholder=" " v-model="inputFields.title" required>
                 <label for="title" class="floating-label">Opgavens navn</label>
-                <div class="button input-button tooltip-hover" @click="toggleSelectTemplate()">
+                <div class="button input-button tooltip-hover" @click="toggleSelectTemplate()" v-if="!isEditing && !isTemplate">
                     <i class="fa-solid fa-folder"></i>
                     <span class="tooltip-display nohover">Vælg skabelon</span>
                 </div>
@@ -418,7 +419,7 @@
                 <div class="button input-button tooltip-hover" @click="toggleAddNewGroup()">
                     <i v-if="isAddingNewGroup" class="fa-solid fa-arrow-left"></i>
                     <i v-else class="fa-solid fa-plus"></i>
-                    <span class="tooltip-display nohover">{{ isAddingNewGroup ? 'Fortryd' : 'Opret skabelon' }}</span>
+                    <span class="tooltip-display nohover">{{ isAddingNewGroup ? 'Fortryd' : 'Opret gruppe' }}</span>
                 </div>
             </div>
 

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -23,6 +23,7 @@
     const selectedTemplate = ref("")
     const selectedGroup = ref("")
     const isAddingNewGroup = ref(false)
+    const isSelectingTemplate = ref(false)
 
     const inputFields = ref({
         title: "",
@@ -115,8 +116,21 @@
     /* Use template */
 
     const selectTemplate = (template) => {
+        isSelectingTemplate.value = false
         if(template == null)
-            return
+        {
+            inputFields.value.title = ""
+            inputFields.value.beskrivelse = ""
+            inputFields.value.note = ""
+            inputFields.value.startdato = ""
+            inputFields.value.slutdato = ""
+            inputFields.value.booking = ""
+            if(addToTemplate.value || isPreparation.value)
+            {
+                inputFields.value.relativ_slutdag = template.relativ_slutdag
+                relativEndday.value = inputFields.value.relativ_slutdag
+            }
+        }
         
         inputFields.value.title = template.title
         inputFields.value.beskrivelse = template.beskrivelse
@@ -144,6 +158,12 @@
             endDate.setDate(endDate.getDate() + daysToAdd)
             inputFields.value.slutdato = endDate.toISOString().split('T')[0]
         }
+    }
+
+    const toggleSelectTemplate = () => {
+        if(!isSelectingTemplate.value && selectedTemplate.value == null)
+            selectedTemplate.value = ""
+        isSelectingTemplate.value = !isSelectingTemplate.value
     }
 
     const selectGroup = (group) => {
@@ -330,125 +350,139 @@
 
 <template>
     <p class="indent-tiny bold uppercase p-header-adjust">
-        {{ isEditing ? 'Rediger opgave' : isTemplate ? 'Opret opgaveskabelon' : 'Tilføj opgave til' }}
-        {{ isTemplate ? '' : ' på ' + forloeb?.name?? 'forløbet' }}
+        {{ isEditing ? 'Rediger opgave' : isTemplate ? 'Opret opgaveskabelon' : 'Tilføj opgave' }}
+        {{ isTemplate ? '' : ' til ' + forloeb?.name?? 'forløbet' }}
     </p>
 
     <form @submit.prevent="submitForm">
     <div class="formContainer">
 
-        <div v-if="!isEditing && !isTemplate" class="inputContainer">
-            <select id="template" name="template" v-model="selectedTemplate" @change="selectTemplate(selectedTemplate)" required>
-                <option value="" disabled selected hidden></option>
-                <option :value="null" style="color:gray">Ingen skabelon</option>
-                <option v-for="template in templates" :value="template">{{template.title}}</option>
-            </select>
-            <label for="template" class="floating-label">Skabelon</label>
-            <div class="icon nohover"><i class="fa-solid fa-caret-down"></i></div>
-        </div>
+        <template v-if="!isEditing && !isTemplate && isSelectingTemplate">
+            <div class="inputContainer">
+                <select id="template" name="template" v-model="selectedTemplate" @change="selectTemplate(selectedTemplate)" required>
+                    <option value="" disabled selected hidden></option>
+                    <option :value="null" style="color:gray">Ingen skabelon</option>
+                    <option v-for="template in templates" :value="template">{{template.title}}</option>
+                </select>
+                <label for="template" class="floating-label">Skabelon</label>
+                <div class="icon nohover adjust-for-button"><i class="fa-solid fa-caret-down"></i></div>
+                <div class="button input-button tooltip-hover" @click="toggleSelectTemplate()">
+                    <i class="fa-solid fa-arrow-left"></i>
+                    <span class="tooltip-display nohover">Fortryd</span>
+                </div>
+            </div>
 
-        <div class="inputContainer">
-            <input type="text" id="title" name="title" placeholder=" " v-model="inputFields.title" required>
-            <label for="title" class="floating-label">Opgavens navn</label>
-        </div>
-        
-        <div class="inputContainer" v-if="!isTemplate && !addToTemplate">
-            <input type="text" id="assistant" name="assistant" placeholder=" " @input="searchAssistants(inputFields.ansvarlig)" v-model="inputFields.ansvarlig" class="locked" :disabled="isAssistantLocked">
-            <label for="assistant" class="floating-label">Ansvarlig medarbejder</label>
-            <div class="icon" @click="toggleassistantSearch()"><i :class="'fa-solid fa-lock' + (isAssistantLocked ? '' : '-open')"></i></div>
+        </template>
+
+        <template v-else>
+            <div class="inputContainer">
+                <input type="text" id="title" name="title" placeholder=" " v-model="inputFields.title" required>
+                <label for="title" class="floating-label">Opgavens navn</label>
+                <div class="button input-button tooltip-hover" @click="toggleSelectTemplate()">
+                    <i class="fa-solid fa-folder"></i>
+                    <span class="tooltip-display nohover">Vælg skabelon</span>
+                </div>
+            </div>
             
-            <div class="itemSelector float-right" v-if="isAssistantSearchOpen">
-                <span class="float-header small uppercase">Vælg en ansvarlig medarbejder ...</span>
-                <div v-for="result in assistantSearchResults" @click="selectAssistant(result)">{{result.name}}</div>
-                <div v-if="assistantSearchResults.length == 0" class="nohover small">Der blev ikke fundet nogle resultater.</div>
+            <div class="inputContainer" v-if="!isTemplate && !addToTemplate">
+                <input type="text" id="assistant" name="assistant" placeholder=" " @input="searchAssistants(inputFields.ansvarlig)" v-model="inputFields.ansvarlig" class="locked" :disabled="isAssistantLocked">
+                <label for="assistant" class="floating-label">Ansvarlig medarbejder</label>
+                <div class="icon" @click="toggleassistantSearch()"><i :class="'fa-solid fa-lock' + (isAssistantLocked ? '' : '-open')"></i></div>
+                
+                <div class="itemSelector float-right" v-if="isAssistantSearchOpen">
+                    <span class="float-header small uppercase">Vælg en ansvarlig medarbejder ...</span>
+                    <div v-for="result in assistantSearchResults" @click="selectAssistant(result)">{{result.name}}</div>
+                    <div v-if="assistantSearchResults.length == 0" class="nohover small">Der blev ikke fundet nogle resultater.</div>
+                </div>
             </div>
-        </div>
 
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]">
-            <textarea id="description" name="description" ref="textareaDescription" @input="resizeTextareaDescriptionToFitContent()" placeholder=" " v-model="inputFields.beskrivelse" required></textarea>
-            <label for="description" class="floating-label">Beskrivelse</label>
-        </div>
-
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]">
-            <textarea id="note" name="note" ref="textareaNote" @input="resizeTextareaNoteToFitContent()" placeholder=" " v-model="inputFields.note"></textarea>
-            <label for="note" class="floating-label">Note til ansvarlig</label>
-        </div>
-
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate">
-            <input v-if="isAddingNewGroup" type="text" id="gruppe" name="gruppe" placeholder="" v-model="inputFields.OpgaveGruppeNavn" required>
-            <select v-else id="gruppe" name="gruppe" v-model="selectedGroup" @change="selectGroup(selectedGroup)" required>
-                <option value="" disabled selected hidden></option>
-                <option :value="null" style="color:gray">Ingen gruppe</option>
-                <option v-for="gruppe in forloeb?.opgave_grupper" :value="gruppe.OpgaveGruppeID">{{gruppe.name}}</option>
-            </select>
-            <label for="gruppe" class="floating-label">{{ isAddingNewGroup ? 'Nyt gruppenavn' : 'Gruppe' }}</label>
-            <div v-if="!isAddingNewGroup" class="icon nohover" style="transform: translateX(-4rem);"><i class="fa-solid fa-caret-down"></i></div>
-            <div class="button input-button" @click="toggleAddNewGroup()">
-                <i v-if="isAddingNewGroup" class="fa-solid fa-arrow-left"></i>
-                <i v-else class="fa-solid fa-plus"></i>
+            <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]">
+                <textarea id="description" name="description" ref="textareaDescription" @input="resizeTextareaDescriptionToFitContent()" placeholder=" " v-model="inputFields.beskrivelse" required></textarea>
+                <label for="description" class="floating-label">Beskrivelse</label>
             </div>
-        </div>
 
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate && !isPreparation">
-            <div class="flex-item">
-                <input type="date" id="startdate" name="startdate" v-model="inputFields.startdato" @change="setEndDateFromTemplate()" required>
-                <label for="startdate" class="floating-label">Startdato</label>
+            <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]">
+                <textarea id="note" name="note" ref="textareaNote" @input="resizeTextareaNoteToFitContent()" placeholder=" " v-model="inputFields.note"></textarea>
+                <label for="note" class="floating-label">Note til ansvarlig</label>
             </div>
-            <div class="flex-item">
-                <input type="date" id="enddate" name="enddate" v-model="inputFields.slutdato" required>
-                <label for="enddate" class="floating-label">Slutdato</label>
+
+            <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate">
+                <input v-if="isAddingNewGroup" type="text" id="gruppe" name="gruppe" placeholder="" v-model="inputFields.OpgaveGruppeNavn" required>
+                <select v-else id="gruppe" name="gruppe" v-model="selectedGroup" @change="selectGroup(selectedGroup)" required>
+                    <option value="" disabled selected hidden></option>
+                    <option :value="null" style="color:gray">Ingen gruppe</option>
+                    <option v-for="gruppe in forloeb?.opgave_grupper" :value="gruppe.OpgaveGruppeID">{{gruppe.name}}</option>
+                </select>
+                <label for="gruppe" class="floating-label">{{ isAddingNewGroup ? 'Nyt gruppenavn' : 'Gruppe' }}</label>
+                <div v-if="!isAddingNewGroup" class="icon nohover" style="transform: translateX(-4rem);"><i class="fa-solid fa-caret-down"></i></div>
+                <div class="button input-button tooltip-hover" @click="toggleAddNewGroup()">
+                    <i v-if="isAddingNewGroup" class="fa-solid fa-arrow-left"></i>
+                    <i v-else class="fa-solid fa-plus"></i>
+                    <span class="tooltip-display nohover">{{ isAddingNewGroup ? 'Fortryd' : 'Opret skabelon' }}</span>
+                </div>
             </div>
-        </div>
 
-        
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate && !isPreparation">
-            <input type="datetime-local" id="booking" name="booking" v-model="inputFields.booking">
-            <label for="booking" class="floating-label">Booking</label>
-        </div>
+            <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate && !isPreparation">
+                <div class="flex-item">
+                    <input type="date" id="startdate" name="startdate" v-model="inputFields.startdato" @change="setEndDateFromTemplate()" required>
+                    <label for="startdate" class="floating-label">Startdato</label>
+                </div>
+                <div class="flex-item">
+                    <input type="date" id="enddate" name="enddate" v-model="inputFields.slutdato" required>
+                    <label for="enddate" class="floating-label">Slutdato</label>
+                </div>
+            </div>
 
-        <!--  Relative start and end days -->
-        <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="isTemplate || addToTemplate || isPreparation">
-            <div v-if="addToTemplate || isPreparation" class="flex-item">
-                <input type="text" id="startdate" class="padding-input" name="startdate"
-                        v-model="inputFields.relativ_startdag" ref="relativStartday"
-                        @input="relativStartday.value=sliceXChars(removeNonIntegers(relativStartday.value), 3)"
-                        required>
-                <label for="startdate" class="floating-label">Startes efter </label>
-                <label for="startdate" class="annot-label">{{ returnDagOrDage(inputFields.relativ_startdag) }}</label>
-                <div :class="['floating-button', 'indent-floating-button']"
-                        @click="inputFields.relativ_startdag--">
+            
+            <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="!isTemplate && !addToTemplate && !isPreparation">
+                <input type="datetime-local" id="booking" name="booking" v-model="inputFields.booking">
+                <label for="booking" class="floating-label">Booking</label>
+            </div>
+
+            <!--  Relative start and end days -->
+            <div :class="['inputContainer', { 'hideOnMobile': isAssistantSearchOpen }]" v-if="isTemplate || addToTemplate || isPreparation">
+                <div v-if="addToTemplate || isPreparation" class="flex-item">
+                    <input type="text" id="startdate" class="padding-input" name="startdate"
+                            v-model="inputFields.relativ_startdag" ref="relativStartday"
+                            @input="relativStartday.value=sliceXChars(removeNonIntegers(relativStartday.value), 3)"
+                            required>
+                    <label for="startdate" class="floating-label">Startes efter </label>
+                    <label for="startdate" class="annot-label">{{ returnDagOrDage(inputFields.relativ_startdag) }}</label>
+                    <div :class="['floating-button', 'indent-floating-button']"
+                            @click="inputFields.relativ_startdag--">
+                                <i class="fa fa-minus"></i>
+                            </div>
+                    <div class="floating-button" 
+                        @click="inputFields.relativ_startdag++">
+                        <i class="fa fa-plus"></i>
+                    </div>
+                </div>
+                <div class="flex-item">
+                    <input type="text" id="enddate" class="padding-input" name="enddate"
+                            v-model="inputFields.relativ_slutdag" ref="relativEndday"
+                            @input="relativEndday.value=inputFields.relativ_slutdag=Math.max(1, sliceXChars(removeNonIntegers(relativEndday.value), 3));relativEnddayAtOne = inputFields.relativ_slutdag==1"
+                            required>
+                    <label for="enddate" class="floating-label">Varighed</label>
+                    <label for="enddate" class="annot-label">{{ returnDagOrDage(inputFields.relativ_slutdag) }}</label>
+                    <div :class="['floating-button', 'indent-floating-button', { 'disabled': relativEnddayAtOne}]"
+                            @click="inputFields.relativ_slutdag--;relativEnddayAtOne = inputFields.relativ_slutdag==1">
                             <i class="fa fa-minus"></i>
                         </div>
-                <div class="floating-button" 
-                    @click="inputFields.relativ_startdag++">
-                    <i class="fa fa-plus"></i>
-                </div>
-            </div>
-            <div class="flex-item">
-                <input type="text" id="enddate" class="padding-input" name="enddate"
-                        v-model="inputFields.relativ_slutdag" ref="relativEndday"
-                        @input="relativEndday.value=inputFields.relativ_slutdag=Math.max(1, sliceXChars(removeNonIntegers(relativEndday.value), 3));relativEnddayAtOne = inputFields.relativ_slutdag==1"
-                        required>
-                <label for="enddate" class="floating-label">Varighed</label>
-                <label for="enddate" class="annot-label">{{ returnDagOrDage(inputFields.relativ_slutdag) }}</label>
-                <div :class="['floating-button', 'indent-floating-button', { 'disabled': relativEnddayAtOne}]"
-                        @click="inputFields.relativ_slutdag--;relativEnddayAtOne = inputFields.relativ_slutdag==1">
-                        <i class="fa fa-minus"></i>
+                    <div class="floating-button" @click="relativEnddayAtOne = false;inputFields.relativ_slutdag++">
+                        <i class="fa fa-plus"></i>
                     </div>
-                <div class="floating-button" @click="relativEnddayAtOne = false;inputFields.relativ_slutdag++">
-                    <i class="fa fa-plus"></i>
                 </div>
             </div>
-        </div>
 
-        <div :class="['inputContainer', 'submit', { 'hideOnMobile': isAssistantSearchOpen }]">
-            <button :class="['button', 'button-outline', { 'disabled': isSubmitting }]"
-                    type="submit"
-                    @click="clearAssistantIfNotSelected();selectNoTemplateIfNotSelected();selectNoGroupIfNotSelected()"
-                    :disabled="isSubmitting">
-                        {{ isEditing ? 'Opdater opgave' : isTemplate ? '+ Opret opgaveskabelon' : '+ Tilføj opgave' }}
-            </button>
-        </div>
+            <div :class="['inputContainer', 'submit', { 'hideOnMobile': isAssistantSearchOpen }]">
+                <button :class="['button', 'button-outline', { 'disabled': isSubmitting }]"
+                        type="submit"
+                        @click="clearAssistantIfNotSelected();selectNoTemplateIfNotSelected();selectNoGroupIfNotSelected()"
+                        :disabled="isSubmitting">
+                            {{ isEditing ? 'Opdater opgave' : isTemplate ? '+ Opret opgaveskabelon' : '+ Tilføj opgave' }}
+                </button>
+            </div>
+        </template>
 
     </div>
     </form>
@@ -469,5 +503,14 @@
         display: flex;
         align-items: center;
         justify-content: center;
+    }
+    .tooltip-display
+    {
+        transform: translate(0, -2.6rem);
+        width: auto;
+        white-space: nowrap;
+    }
+    .icon.adjust-for-button {
+        transform: translateX(-4rem);
     }
 </style>

--- a/vue/src/views/admin/CreateOpgave.vue
+++ b/vue/src/views/admin/CreateOpgave.vue
@@ -328,7 +328,6 @@
 </script>
 
 <template>
-    Er template: {{ isTemplate }}
     <p class="indent-tiny bold uppercase p-header-adjust">
         {{ isEditing ? 'Rediger opgave' : isTemplate ? 'Opret opgaveskabelon' : 'Tilføj opgave til' }}
         {{ isTemplate ? '' : ' på ' + forloeb?.name?? 'forløbet' }}

--- a/vue/src/views/admin/EditForløb.vue
+++ b/vue/src/views/admin/EditForløb.vue
@@ -3,18 +3,16 @@
     import { useRouter, useRoute } from 'vue-router'
 
     import { getUserInfo } from '@/services/keycloakService.js'
-    import { getForloebsskabeloner } from '@/services/forløbsskabelonService.js'
-    import { createForloeb, createForloebPreparation } from '@/services/forløbService.js'
+    import { getForloebById, updateForloeb } from '@/services/forløbService.js'
     import { getAdminData, getUsers } from '@/services/userService.js'
 
     const route = useRoute()
     const router = useRouter()
 
     const isSubmitting = ref(false)
-    const isPreparation = route.query.prep !== 'false'
+    const isPreparation = ref(true)
+    const forloeb_id = parseInt(route.query.id, 10)
 
-	const template_id = parseInt(route.query.tid, 10)
-    const templates = ref([])
     const inputFields = ref({
         usermail: "",
         admin: "",
@@ -67,13 +65,6 @@
         isUserMailSearchOpen.value = false
         evaluateEmail()
     }
-
-    // const getEmailType = () => {
-    //     if (inputFields.value.usermail.includes('@randers.dk')) {
-    //         return 'randersmail'
-    //     }
-    //     return 'private'
-    // }
 
     const evaluateEmail = () => {
         const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -136,38 +127,9 @@
             isAdminSearchOpen.value = false
         }
     }
-    
-    const selectNoTemplateIfNotSelected = () => {
-        if(inputFields.value.ForløbsskabelonID == "")
-            inputFields.value.ForløbsskabelonID = null
-    }
-
-    const setEndDateFromTemplate = () => {
-        const template = templates.value.find(template => template.ForløbsskabelonID === inputFields.value.ForløbsskabelonID)
-        if (template) {
-            const startDate = new Date(inputFields.value.startdate)
-            const daysToAdd = template.varighed
-            var endDate = new Date(startDate)
-            endDate.setDate(endDate.getDate() + daysToAdd)
-            inputFields.value.enddate = endDate.toISOString().split('T')[0]
-        }
-    }
 
     /* Instantiate */
     onMounted(async () => {
-        // Get templates
-        try {
-            const forloebsskabelonerResponse = await getForloebsskabeloner()
-            templates.value = forloebsskabelonerResponse.data
-            if (template_id) {
-                const selectedTemplate = templates.value.find(template => template.ForløbsskabelonID === template_id)
-                if (selectedTemplate)
-                    inputFields.value.ForløbsskabelonID = selectedTemplate.ForløbsskabelonID
-            }
-        } catch (error) {
-            console.error('Error fetching forloebsskabeloner:', error)
-        }
-
         // Get admin list
         try {
             const adminDataResponse = await getAdminData()
@@ -189,6 +151,22 @@
         } catch (error) {
             console.error('Error fetching emails:', error)
         }
+
+        // Get item to edit
+        try {
+            const forloebResponse = await getForloebById(forloeb_id)
+            selectedAdmin.value = adminList.value.find(admin => admin.mail === forloebResponse.data.admin)
+            const formattedData = {
+                ...forloebResponse.data,
+                startdate: forloebResponse.data.startdate ? forloebResponse.data.startdate.split('T')[0] : '',
+                enddate: forloebResponse.data.enddate ? forloebResponse.data.enddate.split('T')[0] : ''
+            }
+            formattedData.admin = selectedAdmin.value.name
+            isPreparation.value = forloebResponse.data.isPreparation
+            Object.assign(inputFields.value, formattedData)
+        } catch (error) {
+            console.error('Error fetching forløb:', error)
+        }
     })
 
     /* Submit */
@@ -204,9 +182,7 @@
             if (!formData.ForløbsskabelonID)
                 delete formData.ForløbsskabelonID
             console.log(formData)
-            const response = isPreparation ?
-                await createForloebPreparation(formData)
-                : await createForloeb(formData)
+            const response = await updateForloeb(forloeb_id, formData)
             if (response.data.uid)
                 router.push({ path: '/forloeb-overview', query: { id: response.data.uid } })
         } catch (error) {
@@ -220,7 +196,7 @@
 </script>
 
 <template>
-    <p class="indent-tiny bold uppercase p-header-adjust">{{ isPreparation ? 'Opret forløbsforberedelse' : 'Opret forløb' }}</p>
+    <p class="indent-tiny bold uppercase p-header-adjust">Rediger forløb</p>
 
     <form @submit.prevent="submitForm">
     <div class="formContainer">
@@ -252,19 +228,19 @@
                 <div v-if="adminSearchResults.length == 0" class="nohover small">Der blev ikke fundet nogle resultater.</div>
             </div>
         </div>
-
-        <div class="inputContainer" :class="{ 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }">
-            <select id="template" name="template" v-model="inputFields.ForløbsskabelonID" required>
-                <option value="" disabled selected hidden></option>
-                <option :value="null" style="color:gray">Ingen skabelon</option>
-                <option v-for="template in templates" :value="template.ForløbsskabelonID">{{template.name}}</option>
-            </select>
-            <label for="template" class="floating-label">Skabelon</label>
-            <div class="icon nohover"><i class="fa-solid fa-caret-down"></i></div>
+        <div v-if="!isPreparation" class="inputContainer" :class="{ 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }">
+            <div class="flex-item">
+                <input type="date" id="startdate" name="startdate" v-model="inputFields.startdate" required>
+                <label for="startdate" class="floating-label">Startdato</label>
+            </div>
+            <div class="flex-item">
+                <input type="date" id="enddate" name="enddate" v-model="inputFields.enddate" required>
+                <label for="enddate" class="floating-label">Slutdato</label>
+            </div>
         </div>
 
         <div class="inputContainer submit">
-            <button :class="['button', 'button-outline', { 'disabled': isSubmitting }, { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]" @click="clearAdminIfNotSelected();selectNoTemplateIfNotSelected()" type="submit" :disabled="isSubmitting">+ Opret forløb</button>
+            <button :class="['button', 'button-outline', { 'disabled': isSubmitting }, { 'hideOnMobile': isUserMailSearchOpen || isAdminSearchOpen }]" @click="clearAdminIfNotSelected()" type="submit" :disabled="isSubmitting">Opdater forløb</button>
         </div>
 
     </div>

--- a/vue/src/views/admin/EditForløb.vue
+++ b/vue/src/views/admin/EditForløb.vue
@@ -253,8 +253,8 @@
             <input type="checkbox" id="planWelcome" name="planWelcome" v-model="inputFields.planWelcome" :disabled="!isRandersMail(inputFields.usermail) || isUserMailSearchOpen || welcomeMailPlanned">
             <label for="planWelcome" :class="['checkbox-label', { 'faded': !isRandersMail(inputFields.usermail) || isUserMailSearchOpen || welcomeMailPlanned }]">
                 Planlæg afsendelse velkomstmail til ny medarbejder<br />
-                <span class="tag" v-if="inputFields.usermail != '' && !isRandersMail(inputFields.usermail)">Kræver at at medarbejderen benytter en @randers.dk-mailadresse</span>
-                <span class="tag green" v-if="welcomeMailPlanned">Velkomstmail allerede planlagt. Slet denne, hvis du ønsker at planlægge en ny.</span>
+                <div class="tag" v-if="inputFields.usermail != '' && !isRandersMail(inputFields.usermail)">Kræver at at medarbejderen benytter en @randers.dk-mailadresse</div>
+                <div class="tag green" v-if="welcomeMailPlanned">Velkomstmail allerede planlagt. Slet denne, hvis du ønsker at planlægge en ny.</div>
             </label>
         </div>
 

--- a/vue/src/views/admin/EditForløb.vue
+++ b/vue/src/views/admin/EditForløb.vue
@@ -191,7 +191,6 @@
             formData.admin = selectedAdmin.value.mail
             if (!formData.ForløbsskabelonID)
                 delete formData.ForløbsskabelonID
-            console.log(formData)
             const response = await updateForloeb(forloeb_id, formData)
             if (response.data.uid)
                 router.push({ path: '/forloeb-overview', query: { id: response.data.uid } })

--- a/vue/src/views/admin/EditForløb.vue
+++ b/vue/src/views/admin/EditForløb.vue
@@ -249,7 +249,7 @@
             </div>
         </div>
 
-        <div :class="['inputContainer checkbox', { 'hideOnMobile': isUserMailSearchOpen }]">
+        <div :class="['inputContainer checkbox', { 'hideOnMobile': isUserMailSearchOpen }]" v-if="!isPreparation">
             <input type="checkbox" id="planWelcome" name="planWelcome" v-model="inputFields.planWelcome" :disabled="!isRandersMail(inputFields.usermail) || isUserMailSearchOpen || welcomeMailPlanned">
             <label for="planWelcome" :class="['checkbox-label', { 'faded': !isRandersMail(inputFields.usermail) || isUserMailSearchOpen || welcomeMailPlanned }]">
                 Planlæg afsendelse velkomstmail til ny medarbejder<br />

--- a/vue/src/views/admin/EditForløb.vue
+++ b/vue/src/views/admin/EditForløb.vue
@@ -49,7 +49,7 @@
                 }
             }
         }
-        if (isAdminSearchOpen) {
+        if (isAdminSearchOpen.value) {
             isAdminSearchOpen.value = false
         }
         if (searchString.length < 3) {
@@ -97,7 +97,7 @@
     })
 
     const searchAdmins = (searchString) => {
-        if (isUserMailSearchOpen) {
+        if (isUserMailSearchOpen.value) {
             isUserMailSearchOpen.value = false
         }
         if (searchString.length < 3) {

--- a/vue/src/views/admin/EditForløb.vue
+++ b/vue/src/views/admin/EditForløb.vue
@@ -20,11 +20,19 @@
         startdate: "",
         enddate: "",
         name: "",
-        userdq: ""
+        userdq: "",
+        planWelcome: false
     })
 
     /* User mail search */
     const isUserMailValid = ref(true)
+    const isRandersMail = (email) => {
+        let result = email.toLowerCase().endsWith('@randers.dk')
+        if (!result)
+            inputFields.value.planWelcome = false
+        return result
+    }
+    const welcomeMailPlanned = ref(false)
     const userList = ref([])
     const userMailSearchResults = ref([])
     const isUserMailSearchOpen = ref(false)
@@ -159,10 +167,12 @@
             const formattedData = {
                 ...forloebResponse.data,
                 startdate: forloebResponse.data.startdate ? forloebResponse.data.startdate.split('T')[0] : '',
-                enddate: forloebResponse.data.enddate ? forloebResponse.data.enddate.split('T')[0] : ''
+                enddate: forloebResponse.data.enddate ? forloebResponse.data.enddate.split('T')[0] : '',
+                planWelcome: forloebResponse.data.pending_emails?.filter(mail => !mail.isSent).length > 0
             }
             formattedData.admin = selectedAdmin.value.name
             isPreparation.value = forloebResponse.data.isPreparation
+            welcomeMailPlanned.value = formattedData.planWelcome
             Object.assign(inputFields.value, formattedData)
         } catch (error) {
             console.error('Error fetching forløb:', error)
@@ -237,6 +247,15 @@
                 <input type="date" id="enddate" name="enddate" v-model="inputFields.enddate" required>
                 <label for="enddate" class="floating-label">Slutdato</label>
             </div>
+        </div>
+
+        <div :class="['inputContainer checkbox', { 'hideOnMobile': isUserMailSearchOpen }]">
+            <input type="checkbox" id="planWelcome" name="planWelcome" v-model="inputFields.planWelcome" :disabled="!isRandersMail(inputFields.usermail) || isUserMailSearchOpen || welcomeMailPlanned">
+            <label for="planWelcome" :class="['checkbox-label', { 'faded': !isRandersMail(inputFields.usermail) || isUserMailSearchOpen || welcomeMailPlanned }]">
+                Planlæg afsendelse velkomstmail til ny medarbejder<br />
+                <span class="tag" v-if="inputFields.usermail != '' && !isRandersMail(inputFields.usermail)">Kræver at at medarbejderen benytter en @randers.dk-mailadresse</span>
+                <span class="tag green" v-if="welcomeMailPlanned">Velkomstmail allerede planlagt. Slet denne, hvis du ønsker at planlægge en ny.</span>
+            </label>
         </div>
 
         <div class="inputContainer submit">

--- a/vue/src/views/admin/StartForløb.vue
+++ b/vue/src/views/admin/StartForløb.vue
@@ -1,0 +1,178 @@
+<script setup>
+    import { ref, onMounted } from 'vue'
+    import { useRouter, useRoute } from 'vue-router'
+    
+    import { getForloebById, startForloeb } from '@/services/forløbService.js'
+    import { getUsers } from '@/services/userService.js'
+
+    const route = useRoute()
+    const router = useRouter()
+
+    const isSubmitting = ref(false)
+    const forloeb_id = parseInt(route.query.id, 10)
+
+    const inputFields = ref({
+        usermail: "",
+        startdate: "",
+        enddate: "",
+        planMails: true
+    })
+
+    /* User mail search */
+    const isUserMailValid = ref(true)
+    const userList = ref([])
+    const userMailSearchResults = ref([])
+    const isUserMailSearchOpen = ref(false)
+
+    const searchUserMails = (searchString) => {
+        if (searchString.includes('@')) {
+            let domain = searchString.split('@')[1]
+            let domainLength = domain.length
+            if (domainLength > 0) {
+                let localDomain = ("randers.dk").substring(0, domainLength)
+                if(localDomain !== domain) {
+                    isUserMailSearchOpen.value = false
+                    return
+                }
+            }
+        }
+        if (searchString.length < 3) {
+            isUserMailSearchOpen.value = false
+            return userMailSearchResults.value = []
+        }
+        isUserMailSearchOpen.value = true
+        searchString = searchString.replace(/Æ/gi, 'a').replace(/Ø/gi, 'o').replace(/Å/gi, 'a')
+        let spacelessSearchString = searchString.replace(/ /g, '.')
+        const searchResults = userList.value.filter(userMail =>
+            userMail.email.toLowerCase().startsWith(searchString.toLowerCase()) ||
+            userMail.email.toLowerCase().startsWith(spacelessSearchString.toLowerCase())
+        )
+        return userMailSearchResults.value = searchResults
+    }
+
+    const selectUserMail = (user) => {
+        inputFields.value.usermail = user.email
+        inputFields.value.userdq = user.dq
+        inputFields.value.name = user.name
+        isUserMailSearchOpen.value = false
+        evaluateEmail()
+    }
+
+    const evaluateEmail = () => {
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+        if (!emailPattern.test(inputFields.value.usermail))
+            return isUserMailValid.value = false
+        return isUserMailValid.value = true
+    }
+    
+    const setEndDateFromSelf = () => {
+        const startDate = new Date(inputFields.value.startdate)
+        const daysToAdd = inputFields.value.varighed
+        var endDate = new Date(startDate)
+        endDate.setDate(endDate.getDate() + daysToAdd)
+        inputFields.value.enddate = endDate.toISOString().split('T')[0]
+    }
+
+    /* Instantiate */
+    onMounted(async () => {
+        if (!forloeb_id) {
+            router.replace('/admin-overview')
+            return
+        }
+        // Get user list
+        try {
+            const userResponse = await getUsers()
+            userList.value = userResponse.data
+        } catch (error) {
+            console.error('Error fetching emails:', error)
+        }
+
+        // Get forløb to start
+        try {
+            const forloebResponse = await getForloebById(forloeb_id)
+            if(forloebResponse.data?.isPreparation === false || forloebResponse.data?.error) {
+                console.error('Error fetching forløb or forløb not in preparation:', forloebResponse.data.error)
+                router.replace('/admin-overview')
+                return
+            }
+            Object.assign(inputFields.value, forloebResponse.data)
+        } catch (error) {
+            console.error('Error fetching forløb:', error)
+        }
+    })
+
+    /* Submit */
+
+    const submitForm = async () =>
+    {
+        evaluateEmail()
+        if (!isUserMailValid.value)
+            return
+        
+        isSubmitting.value = true
+        try {
+            const formData = {
+                ForløbID: forloeb_id,
+                startdate: inputFields.value.startdate,
+                enddate: inputFields.value.enddate,
+                planMails: inputFields.value.planMails
+            }
+            const response = await startForloeb(formData)
+            if(response.data?.uid)
+                router.push({ path: '/forloeb-overview', query: { id: response.data.uid } })
+            
+        } catch (error) {
+            if (error.response?.data?.error)
+                console.error('Error:', error.response.data.error)
+            else 
+                console.error('Error:', error)
+        }
+        isSubmitting.value = false
+    }
+</script>
+
+<template>
+    <p class="indent-tiny bold uppercase p-header-adjust">Start forløb</p>
+
+    <form @submit.prevent="submitForm">
+    <div class="formContainer">
+
+        <div class="inputContainer">
+            <input type="text" id="mail" name="mail" placeholder=" " @input="searchUserMails(inputFields.usermail)" v-model="inputFields.usermail" :class="{'invalid': !isUserMailValid}" required>
+            <label for="mail" class="floating-label">Medarbejder mailadresse</label>
+
+            <div class="itemSelector float-right" v-if="isUserMailSearchOpen">
+                <span class="float-header small uppercase">Vælg en mailadresse ...</span>
+                <div v-for="result in userMailSearchResults" @click="selectUserMail(result)" class="small">{{result.email}}</div>
+                <div v-if="userMailSearchResults.length == 0" class="nohover small">Der blev ikke fundet nogle resultater.</div>
+            </div>
+        </div>
+
+        <div :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen }]">
+            <input type="text" id="name" name="name" placeholder=" " v-model="inputFields.name" required>
+            <label for="name" class="floating-label">Medarbejder navn</label>
+        </div>
+
+        <div :class="['inputContainer', { 'hideOnMobile': isUserMailSearchOpen }]">
+            <div class="flex-item">
+                <input type="date" id="startdate" name="startdate" v-model="inputFields.startdate" @input="setEndDateFromSelf()" required>
+                <label for="startdate" class="floating-label">Startdato</label>
+            </div>
+            <div class="flex-item">
+                <input type="date" id="enddate" name="enddate" v-model="inputFields.enddate" required>
+                <label for="enddate" class="floating-label">Slutdato</label>
+            </div>
+        </div>
+
+        <div :class="['inputContainer checkbox', { 'hideOnMobile': isUserMailSearchOpen }]">
+            <input type="checkbox" id="planMails" name="planMails" v-model="inputFields.planMails">
+            <label for="planMails" class="checkbox-label">Planlæg afsendelse af mails til opgaveansvarlige</label>
+        </div>
+
+        <div class="inputContainer submit">
+            <button :class="['button', 'button-outline', { 'disabled': isSubmitting }, { 'hideOnMobile': isUserMailSearchOpen }]" type="submit" :disabled="isSubmitting">Start forløb</button>
+        </div>
+
+    </div>
+    </form>
+</template>

--- a/vue/src/views/admin/StartForløb.vue
+++ b/vue/src/views/admin/StartForløb.vue
@@ -15,11 +15,18 @@
         usermail: "",
         startdate: "",
         enddate: "",
-        planMails: true
+        planMails: true,
+        planWelcome: false
     })
 
     /* User mail search */
     const isUserMailValid = ref(true)
+    const isRandersMail = (email) => {
+        let result = email.toLowerCase().endsWith('@randers.dk')
+        if (!result)
+            inputFields.value.planWelcome = false
+        return result
+    }
     const userList = ref([])
     const userMailSearchResults = ref([])
     const isUserMailSearchOpen = ref(false)
@@ -56,6 +63,8 @@
         inputFields.value.name = user.name
         isUserMailSearchOpen.value = false
         evaluateEmail()
+        if (isRandersMail(inputFields.value.usermail))
+            inputFields.value.planWelcome = true
     }
 
     const evaluateEmail = () => {
@@ -96,6 +105,8 @@
                 return
             }
             Object.assign(inputFields.value, forloebResponse.data)
+            if (isRandersMail(inputFields.value.usermail))
+                inputFields.value.planWelcome = true
         } catch (error) {
             console.error('Error fetching forløb:', error)
         }
@@ -115,7 +126,8 @@
                 ForløbID: forloeb_id,
                 startdate: inputFields.value.startdate,
                 enddate: inputFields.value.enddate,
-                planMails: inputFields.value.planMails
+                planMails: inputFields.value.planMails,
+                planWelcome: inputFields.value.planWelcome
             }
             const response = await startForloeb(formData)
             if(response.data?.uid)
@@ -165,8 +177,18 @@
         </div>
 
         <div :class="['inputContainer checkbox', { 'hideOnMobile': isUserMailSearchOpen }]">
+            <input type="checkbox" id="planWelcome" name="planWelcome" v-model="inputFields.planWelcome" :disabled="!isRandersMail(inputFields.usermail) || isUserMailSearchOpen">
+            <label for="planWelcome" :class="['checkbox-label', { 'faded': !isRandersMail(inputFields.usermail) || isUserMailSearchOpen }]">
+                Planlæg afsendelse velkomstmail til ny medarbejder<br />
+                <span class="tag" v-if="inputFields.usermail != '' && !isRandersMail(inputFields.usermail)">Kræver at at medarbejderen benytter en @randers.dk-mailadresse</span>
+            </label>
+        </div>
+
+        <div :class="['inputContainer checkbox', { 'hideOnMobile': isUserMailSearchOpen }]">
             <input type="checkbox" id="planMails" name="planMails" v-model="inputFields.planMails">
-            <label for="planMails" class="checkbox-label">Planlæg afsendelse af mails til opgaveansvarlige</label>
+            <label for="planMails" class="checkbox-label">
+                Planlæg afsendelse af mails til opgaveansvarlige
+            </label>
         </div>
 
         <div class="inputContainer submit">

--- a/vue/src/views/admin/StartForløb.vue
+++ b/vue/src/views/admin/StartForløb.vue
@@ -180,7 +180,7 @@
             <input type="checkbox" id="planWelcome" name="planWelcome" v-model="inputFields.planWelcome" :disabled="!isRandersMail(inputFields.usermail) || isUserMailSearchOpen">
             <label for="planWelcome" :class="['checkbox-label', { 'faded': !isRandersMail(inputFields.usermail) || isUserMailSearchOpen }]">
                 Planlæg afsendelse velkomstmail til ny medarbejder<br />
-                <span class="tag" v-if="inputFields.usermail != '' && !isRandersMail(inputFields.usermail)">Kræver at at medarbejderen benytter en @randers.dk-mailadresse</span>
+                <div class="tag" v-if="inputFields.usermail != '' && !isRandersMail(inputFields.usermail)">Kræver at at medarbejderen benytter en @randers.dk-mailadresse</div>
             </label>
         </div>
 


### PR DESCRIPTION
Add functionality to prepare courses (forløb) before starting them. User is working with relative dates as long as a course is being prepared, and converted to real dates once the course is started, and the start date is set. 

Also added more mail features, allowing the user to plan mails for both users responsible for helping completing tasks, and for the new colleague once the course is started (welcome mail with overview). The user can see planned mails in the interface, and delete them if needed.

More small changes, such as better task template selection UX, split logic between editing courses and creating new courses to two individual vue files from one, updated some CSS for better usability etc.