### PR TITLE
Implement initial email link access flow

### DIFF
--- a/python/src/api_endpoints.py
+++ b/python/src/api_endpoints.py
@@ -61,12 +61,38 @@ from controllers.opgaveskabelon_controller import (
     delete_opgaveskabelon,
     get_opgaveskabelon
 )
+from controllers.external_access_controller import (
+    request_external_access,
+    get_external_userinfo,
+    get_forloeb_external,
+    get_opgaver_forloeb_external,
+)
 from utils.mail_service import purge_mails, send_all_mails, get_planned_mails, delete_planned_mail
 
 logger = logging.getLogger(__name__)
 db_client = get_db_client()
 
 api_endpoints = Blueprint('api', __name__, url_prefix='/api')
+
+
+@api_endpoints.route('/external/request-access', methods=['POST'])
+def request_external_access_endpoint():
+    return request_external_access()
+
+
+@api_endpoints.route('/external/userinfo', methods=['GET'])
+def external_userinfo_endpoint():
+    return get_external_userinfo()
+
+
+@api_endpoints.route('/external/forloeb/<int:forloeb_id>', methods=['GET'])
+def external_forloeb_by_id_endpoint(forloeb_id):
+    return get_forloeb_external(forloeb_id)
+
+
+@api_endpoints.route('/external/opgave/forloeb/<int:forloeb_id>', methods=['GET'])
+def external_opgaver_by_forloeb_id_endpoint(forloeb_id):
+    return get_opgaver_forloeb_external(forloeb_id)
 
 
 @api_endpoints.route('/mitforloeb', methods=['GET'])

--- a/python/src/controllers/external_access_controller.py
+++ b/python/src/controllers/external_access_controller.py
@@ -76,7 +76,7 @@ def request_external_access():
         link = f"{base_url}/forloeb-overview?{query}"
 
         subject, message = create_mail_external_access(forloeb, link, expires_at)
-        sent = send_mail(forloeb.usermail, subject, message)
+        sent = send_mail(forloeb.usermail, subject, message, attachments=None, reply_to=forloeb.admin)
         if not sent:
             logger.error("Failed sending external access email for ForløbID=%s with link %s", forloeb_id_int, link)
 

--- a/python/src/controllers/external_access_controller.py
+++ b/python/src/controllers/external_access_controller.py
@@ -29,6 +29,17 @@ def _hash_access_key(access_key: str) -> str:
     return hashlib.sha256(access_key.encode('utf-8')).hexdigest()
 
 
+def _get_access_key_from_request(default: str = '') -> str:
+    """Fetch accessKey without relying on URL query params.
+
+    Uses header-based transport to avoid access keys being captured in URL logs.
+    """
+    header_value = request.headers.get('X-External-Access-Key')
+    if header_value:
+        return header_value
+    return default
+
+
 def _is_valid_access_key(forloeb: Forløb, access_key: str) -> bool:
     if not access_key or not isinstance(access_key, str):
         return False
@@ -92,8 +103,10 @@ def request_external_access():
         session.commit()
 
         base_url = request.url_root.rstrip('/')
-        query = urlencode({"id": forloeb_id_int, "external": "true", "accessKey": access_key})
-        link = f"{base_url}/forloeb-overview?{query}"
+        # Put accessKey in the URL fragment to avoid it being sent in Referer headers
+        # and being captured in query-string logs. The SPA reads the fragment.
+        query = urlencode({"id": forloeb_id_int, "external": "true"})
+        link = f"{base_url}/forloeb-overview?{query}#accessKey={access_key}"
 
         subject, message = create_mail_external_access(forloeb, link, expires_at)
         sent = send_mail(forloeb.usermail, subject, message, attachments=None, reply_to=forloeb.admin)
@@ -112,12 +125,14 @@ def request_external_access():
 
 
 def get_external_userinfo():
-    """GET /api/external/userinfo?forloebId=..&accessKey=..
+    """GET /api/external/userinfo?forloebId=..
+
+    The access key is expected in the `X-External-Access-Key` header.
 
     Returns a Public userInfo with the forløb usermail as email.
     """
     forloeb_id = request.args.get('forloebId')
-    access_key = request.args.get('accessKey', '')
+    access_key = _get_access_key_from_request('')
 
     try:
         forloeb_id_int = int(forloeb_id)
@@ -130,17 +145,22 @@ def get_external_userinfo():
         if not forloeb or not _is_valid_access_key(forloeb, access_key):
             return jsonify({"error": "Invalid access"}), 403
 
-        return jsonify({
+        response = jsonify({
             "roles": ["Public"],
             "email": forloeb.usermail,
-        }), 200
+        })
+        response.headers['Cache-Control'] = 'no-store'
+        return response, 200
     finally:
         session.close()
 
 
 def get_forloeb_external(forloeb_id: int):
-    """GET /api/external/forloeb/<id>?accessKey=.. (read-only)."""
-    access_key = request.args.get('accessKey', '')
+    """GET /api/external/forloeb/<id> (read-only).
+
+    The access key is expected in the `X-External-Access-Key` header.
+    """
+    access_key = _get_access_key_from_request('')
 
     session = db_client.get_session()
     try:
@@ -178,8 +198,11 @@ def get_forloeb_external(forloeb_id: int):
 
 
 def get_opgaver_forloeb_external(forloeb_id: int):
-    """GET /api/external/opgave/forloeb/<id>?accessKey=.. (read-only)."""
-    access_key = request.args.get('accessKey', '')
+    """GET /api/external/opgave/forloeb/<id> (read-only).
+
+    The access key is expected in the `X-External-Access-Key` header.
+    """
+    access_key = _get_access_key_from_request('')
 
     session = db_client.get_session()
     try:

--- a/python/src/controllers/external_access_controller.py
+++ b/python/src/controllers/external_access_controller.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 from flask import jsonify, request
+from sqlalchemy.orm import selectinload
 
 from models import Forløb, Opgave, OpgaveGruppe
 from utils.db_connection import get_db_client
@@ -186,7 +187,16 @@ def get_opgaver_forloeb_external(forloeb_id: int):
         if not forloeb or not _is_valid_access_key(forloeb, access_key):
             return jsonify({"error": "Invalid access"}), 403
 
-        opgaver = session.query(Opgave).filter_by(ForløbID=forloeb_id).all()
+        # Avoid N+1 queries when iterating opgaver and accessing relationships.
+        opgaver = (
+            session.query(Opgave)
+            .options(
+                selectinload(Opgave.ressource),
+                selectinload(Opgave.opgavegruppe),
+            )
+            .filter_by(ForløbID=forloeb_id)
+            .all()
+        )
 
         result = []
         for opgave in opgaver:

--- a/python/src/controllers/external_access_controller.py
+++ b/python/src/controllers/external_access_controller.py
@@ -7,13 +7,17 @@ from urllib.parse import urlencode
 
 from flask import jsonify, request
 
-from models import Forløb, Opgave, OpgaveGruppe, Ressource
+from models import Forløb, Opgave, OpgaveGruppe
 from utils.db_connection import get_db_client
 from utils.mail_service import send_mail, create_mail_external_access
 
 logger = logging.getLogger(__name__)
 
 db_client = get_db_client()
+
+
+_EXTERNAL_ACCESS_TTL = timedelta(hours=1)
+_EXTERNAL_ACCESS_COOLDOWN = timedelta(minutes=1)
 
 
 def _utc_now():
@@ -64,8 +68,23 @@ def request_external_access():
         if not forloeb:
             return jsonify({"message": "If the forløb exists, an email has been sent."}), 200
 
+        # Basic throttling to reduce email spam: do not re-issue/send if an unexpired
+        # key was generated very recently for this Forløb.
+        existing_hash = getattr(forloeb, 'external_access_key_hash', None)
+        existing_expires_at = getattr(forloeb, 'external_access_expires_at', None)
+        if existing_hash and existing_expires_at:
+            expires_at = existing_expires_at
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            now = _utc_now()
+
+            if now < expires_at:
+                issued_at = expires_at - _EXTERNAL_ACCESS_TTL
+                if now - issued_at < _EXTERNAL_ACCESS_COOLDOWN:
+                    return jsonify({"message": "If the forløb exists, an email has been sent."}), 200
+
         access_key = secrets.token_urlsafe(32)
-        expires_at = _utc_now() + timedelta(hours=1)
+        expires_at = _utc_now() + _EXTERNAL_ACCESS_TTL
 
         forloeb.external_access_key_hash = _hash_access_key(access_key)
         forloeb.external_access_expires_at = expires_at.replace(tzinfo=None)

--- a/python/src/controllers/external_access_controller.py
+++ b/python/src/controllers/external_access_controller.py
@@ -78,7 +78,7 @@ def request_external_access():
         subject, message = create_mail_external_access(forloeb, link, expires_at)
         sent = send_mail(forloeb.usermail, subject, message, attachments=None, reply_to=forloeb.admin)
         if not sent:
-            logger.error("Failed sending external access email for ForløbID=%s with link %s", forloeb_id_int, link)
+            logger.error("Failed sending external access email for ForløbID=%s", forloeb_id_int)
 
         return jsonify({"message": "If the forløb exists, an email has been sent."}), 200
 
@@ -171,32 +171,31 @@ def get_opgaver_forloeb_external(forloeb_id: int):
 
         result = []
         for opgave in opgaver:
-            ressources = session.query(Ressource).filter_by(OpgaveID=opgave.OpgaveID).all()
             result.append({
-                "OpgaveID": opgave.OpgaveID,
-                "title": opgave.title,
-                "beskrivelse": opgave.beskrivelse,
-                "ansvarlig": opgave.ansvarlig,
-                "ansvarligEmail": opgave.ansvarligEmail,
-                "startdato": opgave.startdato.isoformat() if opgave.startdato else None,
-                "slutdato": opgave.slutdato.isoformat() if opgave.slutdato else None,
-                "relativ_startdag": opgave.relativ_startdag,
-                "relativ_slutdag": opgave.relativ_slutdag,
-                "result": opgave.result,
-                "booking": opgave.booking.isoformat() if opgave.booking else None,
-                "timestamp": opgave.timestamp.isoformat() if opgave.timestamp else None,
-                "ForløbID": opgave.ForløbID,
-                "OpgaveGruppeID": opgave.OpgaveGruppeID,
-                "note": opgave.note,
-                "ressource": [
+                'OpgaveID': opgave.OpgaveID,
+                'title': opgave.title,
+                'beskrivelse': opgave.beskrivelse,
+                'resourcer': [
                     {
-                        "RessourceID": r.RessourceID,
-                        "name": r.name,
-                        "url": r.url,
-                        "OpgaveID": r.OpgaveID,
-                    }
-                    for r in ressources
+                        'RessourceID': ressource.RessourceID,
+                        'name': ressource.name,
+                        'url': ressource.url
+                    } for ressource in opgave.ressource
                 ],
+                'gruppe': {
+                    'OpgaveGruppeID': opgave.opgavegruppe.OpgaveGruppeID,
+                    'name': opgave.opgavegruppe.name,
+                    'letter': opgave.opgavegruppe.letter
+                } if opgave.opgavegruppe else None,
+                'ansvarlig': opgave.ansvarlig,
+                'ansvarligEmail': opgave.ansvarligEmail,
+                'startdato': opgave.startdato.isoformat() if opgave.startdato else None,
+                'slutdato': opgave.slutdato.isoformat() if opgave.slutdato else None,
+                'relativ_startdag': opgave.relativ_startdag,
+                'relativ_slutdag': opgave.relativ_slutdag,
+                'result': opgave.result,
+                'booking': opgave.booking.isoformat() if opgave.booking else None,
+                'timestamp': opgave.timestamp.isoformat()
             })
 
         response = jsonify(result)

--- a/python/src/controllers/external_access_controller.py
+++ b/python/src/controllers/external_access_controller.py
@@ -1,0 +1,206 @@
+import hashlib
+import hmac
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+from flask import jsonify, request
+
+from models import Forløb, Opgave, OpgaveGruppe, Ressource
+from utils.db_connection import get_db_client
+from utils.mail_service import send_mail, create_mail_external_access
+
+logger = logging.getLogger(__name__)
+
+db_client = get_db_client()
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+def _hash_access_key(access_key: str) -> str:
+    return hashlib.sha256(access_key.encode('utf-8')).hexdigest()
+
+
+def _is_valid_access_key(forloeb: Forløb, access_key: str) -> bool:
+    if not access_key or not isinstance(access_key, str):
+        return False
+    if not getattr(forloeb, 'external_access_key_hash', None):
+        return False
+    expires_at = getattr(forloeb, 'external_access_expires_at', None)
+    if not expires_at:
+        return False
+
+    # DB timestamps may be naive; treat them as UTC.
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    if _utc_now() > expires_at:
+        return False
+
+    candidate_hash = _hash_access_key(access_key)
+    return hmac.compare_digest(candidate_hash, forloeb.external_access_key_hash)
+
+
+def request_external_access():
+    """POST /api/external/request-access { forloebId: number }
+
+    Always returns a generic success response to reduce enumeration.
+    """
+    payload = request.get_json(silent=True) or {}
+    forloeb_id = payload.get('forloebId')
+
+    try:
+        forloeb_id_int = int(forloeb_id)
+    except (TypeError, ValueError):
+        # Generic response
+        return jsonify({"message": "If the forløb exists, an email has been sent."}), 200
+
+    session = db_client.get_session()
+    try:
+        forloeb = session.query(Forløb).filter_by(ForløbID=forloeb_id_int).first()
+        if not forloeb:
+            return jsonify({"message": "If the forløb exists, an email has been sent."}), 200
+
+        access_key = secrets.token_urlsafe(32)
+        expires_at = _utc_now() + timedelta(hours=1)
+
+        forloeb.external_access_key_hash = _hash_access_key(access_key)
+        forloeb.external_access_expires_at = expires_at.replace(tzinfo=None)
+        session.commit()
+
+        base_url = request.url_root.rstrip('/')
+        query = urlencode({"id": forloeb_id_int, "external": "true", "accessKey": access_key})
+        link = f"{base_url}/forloeb-overview?{query}"
+
+        subject, message = create_mail_external_access(forloeb, link, expires_at)
+        sent = send_mail(forloeb.usermail, subject, message)
+        if not sent:
+            logger.error("Failed sending external access email for ForløbID=%s with link %s", forloeb_id_int, link)
+
+        return jsonify({"message": "If the forløb exists, an email has been sent."}), 200
+
+    except Exception as e:
+        session.rollback()
+        logger.exception("Error requesting external access: %s", e)
+        # Generic response
+        return jsonify({"message": "If the forløb exists, an email has been sent."}), 200
+    finally:
+        session.close()
+
+
+def get_external_userinfo():
+    """GET /api/external/userinfo?forloebId=..&accessKey=..
+
+    Returns a Public userInfo with the forløb usermail as email.
+    """
+    forloeb_id = request.args.get('forloebId')
+    access_key = request.args.get('accessKey', '')
+
+    try:
+        forloeb_id_int = int(forloeb_id)
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid access"}), 403
+
+    session = db_client.get_session()
+    try:
+        forloeb = session.query(Forløb).filter_by(ForløbID=forloeb_id_int).first()
+        if not forloeb or not _is_valid_access_key(forloeb, access_key):
+            return jsonify({"error": "Invalid access"}), 403
+
+        return jsonify({
+            "roles": ["Public"],
+            "email": forloeb.usermail,
+        }), 200
+    finally:
+        session.close()
+
+
+def get_forloeb_external(forloeb_id: int):
+    """GET /api/external/forloeb/<id>?accessKey=.. (read-only)."""
+    access_key = request.args.get('accessKey', '')
+
+    session = db_client.get_session()
+    try:
+        forloeb = session.query(Forløb).filter_by(ForløbID=forloeb_id).first()
+        if not forloeb or not _is_valid_access_key(forloeb, access_key):
+            return jsonify({"error": "Invalid access"}), 403
+
+        opgave_grupper = session.query(OpgaveGruppe).filter_by(ForløbID=forloeb.ForløbID).all()
+
+        result = {
+            "ForløbID": forloeb.ForløbID,
+            "name": forloeb.name,
+            "startdate": forloeb.startdate.isoformat() if forloeb.startdate else None,
+            "enddate": forloeb.enddate.isoformat() if forloeb.enddate else None,
+            "usermail": forloeb.usermail,
+            "userdq": forloeb.userdq,
+            "opgave_grupper": [
+                {
+                    "OpgaveGruppeID": gruppe.OpgaveGruppeID,
+                    "name": gruppe.name,
+                    "letter": gruppe.letter,
+                }
+                for gruppe in opgave_grupper
+            ],
+            "isPreparation": forloeb.isPreparation,
+            "varighed": forloeb.varighed,
+            "pending_emails": [],
+        }
+
+        response = jsonify(result)
+        response.headers['Cache-Control'] = 'no-store'
+        return response, 200
+    finally:
+        session.close()
+
+
+def get_opgaver_forloeb_external(forloeb_id: int):
+    """GET /api/external/opgave/forloeb/<id>?accessKey=.. (read-only)."""
+    access_key = request.args.get('accessKey', '')
+
+    session = db_client.get_session()
+    try:
+        forloeb = session.query(Forløb).filter_by(ForløbID=forloeb_id).first()
+        if not forloeb or not _is_valid_access_key(forloeb, access_key):
+            return jsonify({"error": "Invalid access"}), 403
+
+        opgaver = session.query(Opgave).filter_by(ForløbID=forloeb_id).all()
+
+        result = []
+        for opgave in opgaver:
+            ressources = session.query(Ressource).filter_by(OpgaveID=opgave.OpgaveID).all()
+            result.append({
+                "OpgaveID": opgave.OpgaveID,
+                "title": opgave.title,
+                "beskrivelse": opgave.beskrivelse,
+                "ansvarlig": opgave.ansvarlig,
+                "ansvarligEmail": opgave.ansvarligEmail,
+                "startdato": opgave.startdato.isoformat() if opgave.startdato else None,
+                "slutdato": opgave.slutdato.isoformat() if opgave.slutdato else None,
+                "relativ_startdag": opgave.relativ_startdag,
+                "relativ_slutdag": opgave.relativ_slutdag,
+                "result": opgave.result,
+                "booking": opgave.booking.isoformat() if opgave.booking else None,
+                "timestamp": opgave.timestamp.isoformat() if opgave.timestamp else None,
+                "ForløbID": opgave.ForløbID,
+                "OpgaveGruppeID": opgave.OpgaveGruppeID,
+                "note": opgave.note,
+                "ressource": [
+                    {
+                        "RessourceID": r.RessourceID,
+                        "name": r.name,
+                        "url": r.url,
+                        "OpgaveID": r.OpgaveID,
+                    }
+                    for r in ressources
+                ],
+            })
+
+        response = jsonify(result)
+        response.headers['Cache-Control'] = 'no-store'
+        return response, 200
+    finally:
+        session.close()

--- a/python/src/controllers/forloeb_controller.py
+++ b/python/src/controllers/forloeb_controller.py
@@ -4,6 +4,7 @@ from models import Forløb, Forløbsskabelon, Opgave, Ressource, OpgaveGruppe
 from utils.db_connection import get_db_client
 from utils.mail_service import plan_mail, create_mail_ansvarlig, create_mail_forloeb_start
 import logging
+from sqlalchemy.orm import selectinload
 
 logger = logging.getLogger(__name__)
 
@@ -319,13 +320,20 @@ def get_forloeb_by_email(mail):
 def get_forloeb_by_admin(admin_name):
     session = db_client.get_session()
     try:
-        forloeb_list = session.query(Forløb).filter_by(admin=admin_name).all()
+        forloeb_list = (
+            session.query(Forløb)
+            .options(
+                selectinload(Forløb.opgave_grupper),
+                selectinload(Forløb.mails),
+            )
+            .filter_by(admin=admin_name)
+            .all()
+        )
         if not forloeb_list:
             return jsonify([]), 200
 
         result = []
         for forloeb in forloeb_list:
-            opgave_grupper = session.query(OpgaveGruppe).filter_by(ForløbID=forloeb.ForløbID).all()
             result.append(
                 {
                     "ForløbID": forloeb.ForløbID,
@@ -341,7 +349,7 @@ def get_forloeb_by_admin(admin_name):
                             "name": gruppe.name,
                             "letter": gruppe.letter,
                         }
-                        for gruppe in opgave_grupper
+                        for gruppe in forloeb.opgave_grupper
                     ],
                     "isPreparation": forloeb.isPreparation,
                     "varighed": forloeb.varighed,

--- a/python/src/controllers/forloebsskabelon_controller.py
+++ b/python/src/controllers/forloebsskabelon_controller.py
@@ -1,6 +1,7 @@
 from flask import request, jsonify
 from models import Forløbsskabelon, Opgave, OpgaveGruppe
 from utils.db_connection import get_db_client
+from sqlalchemy.orm import selectinload
 
 db_client = get_db_client()
 
@@ -29,23 +30,25 @@ def create_forloebsskabelon():
 def get_all_forloebsskabeloner():
     session = db_client.get_session()
     try:
-        forloebsskabeloner = session.query(Forløbsskabelon).all()
+        forloebsskabeloner = (
+            session.query(Forløbsskabelon)
+            .options(selectinload(Forløbsskabelon.opgave_grupper))
+            .all()
+        )
         forloebsskabeloner_data = [
             {
                 'ForløbsskabelonID': forloebsskabelon.ForløbsskabelonID,
                 'name': forloebsskabelon.name,
-                'varighed': forloebsskabelon.varighed
+                'varighed': forloebsskabelon.varighed,
+                'opgave_grupper': [
+                    {
+                        'OpgaveGruppeID': opgave_gruppe.OpgaveGruppeID,
+                        'name': opgave_gruppe.name,
+                        'letter': opgave_gruppe.letter
+                    } for opgave_gruppe in forloebsskabelon.opgave_grupper
+                ]
             } for forloebsskabelon in forloebsskabeloner
         ]
-        for skabelon in forloebsskabeloner_data:
-            opgave_grupper = session.query(OpgaveGruppe).filter_by(ForløbsskabelonID=skabelon['ForløbsskabelonID']).all()
-            skabelon['opgave_grupper'] = [
-                {
-                    'OpgaveGruppeID': opgave_gruppe.OpgaveGruppeID,
-                    'name': opgave_gruppe.name,
-                    'letter': opgave_gruppe.letter
-                } for opgave_gruppe in opgave_grupper
-            ]
         return jsonify(forloebsskabeloner_data)
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -592,7 +592,7 @@ def notify_expired_tasks():
     session = db_client.get_session()
     try:
         now = datetime.now()
-        opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result is False, Opgave.ForløbID is not None).all()
+        opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result.is_(False), Opgave.ForløbID.is_not(None)).all()
         logger.info(f"Found {len(opgaver)} expired tasks to notify.")
 
         for opgave in opgaver:

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -4,6 +4,7 @@ from models import Opgave, Forløb, Forløbsskabelon, Opgaveskabelon, Ressource,
 from utils.db_connection import get_db_client
 from utils.mail_service import plan_mail, create_mail_ansvarlig, create_mail_expired_ansvarlig, create_mail_expired
 import logging
+from sqlalchemy.orm import selectinload
 
 db_client = get_db_client()
 logger = logging.getLogger(__name__)
@@ -101,7 +102,14 @@ def create_opgavegruppe(name, forløb_id=None, forloeb_skabelon_id=None):
 def get_all_opgaver():
     session = db_client.get_session()
     try:
-        opgaver = session.query(Opgave).all()
+        opgaver = (
+            session.query(Opgave)
+            .options(
+                selectinload(Opgave.ressource),
+                selectinload(Opgave.opgavegruppe),
+            )
+            .all()
+        )
         opgave_data = [
             {
                 'OpgaveID': opgave.OpgaveID,
@@ -220,7 +228,15 @@ def get_opgave_by_forloebsskabelon_id(forlobsskabelon_id):
     try:
         usermail = request.headers.get('usermail')
 
-        query = session.query(Opgave).join(Forløb).filter(Opgave.ForløbsskabelonID == forlobsskabelon_id)
+        query = (
+            session.query(Opgave)
+            .options(
+                selectinload(Opgave.ressource),
+                selectinload(Opgave.opgavegruppe),
+            )
+            .join(Forløb)
+            .filter(Opgave.ForløbsskabelonID == forlobsskabelon_id)
+        )
         if usermail:
             query = query.filter(Forløb.usermail == usermail)
 
@@ -310,7 +326,15 @@ def get_opgave(opgave_id):
 def get_opgave_by_forloebsskabelon_id_admin(forlobsskabelon_id):
     session = db_client.get_session()
     try:
-        opgave = session.query(Opgave).filter_by(ForløbsskabelonID=forlobsskabelon_id).all()
+        opgave = (
+            session.query(Opgave)
+            .options(
+                selectinload(Opgave.ressource),
+                selectinload(Opgave.opgavegruppe),
+            )
+            .filter_by(ForløbsskabelonID=forlobsskabelon_id)
+            .all()
+        )
         if not opgave:
             return jsonify([])
 
@@ -353,7 +377,16 @@ def get_opgave_by_forloebsskabelon_id_admin(forlobsskabelon_id):
 def get_opgave_by_forloeb_id_admin(forlob_id):
     session = db_client.get_session()
     try:
-        opgave = session.query(Opgave).filter_by(ForløbID=forlob_id).all()
+        opgave = (
+            session.query(Opgave)
+            .options(
+                selectinload(Opgave.ressource),
+                selectinload(Opgave.opgavegruppe),
+                selectinload(Opgave.mails),
+            )
+            .filter_by(ForløbID=forlob_id)
+            .all()
+        )
         if not opgave:
             return jsonify([])
 
@@ -403,7 +436,15 @@ def get_opgave_by_forloeb_id_admin(forlob_id):
 def get_opgave_by_admin(adminmail):  # Admin = ansvarlig in this case, bad naming
     session = db_client.get_session()
     try:
-        query = session.query(Opgave).filter(Opgave.ansvarligEmail.ilike(adminmail.lower()))
+        query = (
+            session.query(Opgave)
+            .options(
+                selectinload(Opgave.ressource),
+                selectinload(Opgave.opgavegruppe),
+                selectinload(Opgave.forløb),
+            )
+            .filter(Opgave.ansvarligEmail.ilike(adminmail.lower()))
+        )
         opgave = query.all()
 
         if not opgave:
@@ -411,11 +452,7 @@ def get_opgave_by_admin(adminmail):  # Admin = ansvarlig in this case, bad namin
 
         opgave_data = []
         for opg in opgave:
-            forloeb_name = None
-            if opg.ForløbID:
-                forloeb = session.query(Forløb).filter_by(ForløbID=opg.ForløbID).first()
-                if forloeb:
-                    forloeb_name = forloeb.name
+            forloeb_name = opg.forløb.name if getattr(opg, 'forløb', None) else None
 
             opgave_data.append({
                 'OpgaveID': opg.OpgaveID,
@@ -460,7 +497,15 @@ def get_opgave_by_forloeb_id(forlob_id):
     try:
         usermail = request.headers.get('usermail')
 
-        query = session.query(Opgave).join(Forløb).filter(Opgave.ForløbID == forlob_id)
+        query = (
+            session.query(Opgave)
+            .options(
+                selectinload(Opgave.ressource),
+                selectinload(Opgave.opgavegruppe),
+            )
+            .join(Forløb)
+            .filter(Opgave.ForløbID == forlob_id)
+        )
         if usermail:
             query = query.filter(Forløb.usermail == usermail)
 
@@ -592,11 +637,16 @@ def notify_expired_tasks():
     session = db_client.get_session()
     try:
         now = datetime.now()
-        opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result.is_(False), Opgave.ForløbID.is_not(None)).all()
+        opgaver = (
+            session.query(Opgave)
+            .options(selectinload(Opgave.forløb))
+            .filter(Opgave.slutdato < now, Opgave.result.is_(False), Opgave.ForløbID.is_not(None))
+            .all()
+        )
         logger.info(f"Found {len(opgaver)} expired tasks to notify.")
 
         for opgave in opgaver:
-            forloeb = session.query(Forløb).filter_by(ForløbID=opgave.ForløbID).first()
+            forloeb = getattr(opgave, 'forløb', None)
             if not forloeb:
                 return jsonify({"error": "Forløb not found"}), 404
 

--- a/python/src/controllers/opgave_controller.py
+++ b/python/src/controllers/opgave_controller.py
@@ -592,7 +592,7 @@ def notify_expired_tasks():
     session = db_client.get_session()
     try:
         now = datetime.now()
-        opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result == False, Opgave.ForløbID != None).all()
+        opgaver = session.query(Opgave).filter(Opgave.slutdato < now, Opgave.result is False, Opgave.ForløbID is not None).all()
         logger.info(f"Found {len(opgaver)} expired tasks to notify.")
 
         for opgave in opgaver:

--- a/python/src/controllers/opgaveskabelon_controller.py
+++ b/python/src/controllers/opgaveskabelon_controller.py
@@ -1,6 +1,7 @@
 from flask import request, jsonify
 from models import Opgaveskabelon
 from utils.db_connection import get_db_client
+from sqlalchemy.orm import selectinload
 
 db_client = get_db_client()
 
@@ -33,7 +34,11 @@ def create_opgaveskabelon():
 def get_all_opgaveskabeloner():
     session = db_client.get_session()
     try:
-        opgaveskabeloner = session.query(Opgaveskabelon).all()
+        opgaveskabeloner = (
+            session.query(Opgaveskabelon)
+            .options(selectinload(Opgaveskabelon.ressource))
+            .all()
+        )
         opgaveskabeloner_data = [
             {
                 'OpgaveskabelonID': opgaveskabelon.OpgaveskabelonID,

--- a/python/src/main.py
+++ b/python/src/main.py
@@ -15,7 +15,14 @@ set_logging_configuration()
 
 def create_app():
     app = Flask(__name__, static_folder='dist')
-    CORS(app)
+    CORS(app, allow_headers=['Content-Type', 'usermail', 'X-External-Access-Key'])
+
+    @app.after_request
+    def add_security_headers(response):
+        # Defense-in-depth: avoid sending URLs as referrers to other origins.
+        # (Fragments aren't included in Referer, but this also covers other URLs.)
+        response.headers.setdefault('Referrer-Policy', 'no-referrer')
+        return response
 
     if DISABLE_KEYCLOAK:
         @app.route('/api/userinfo')

--- a/python/src/main.py
+++ b/python/src/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, redirect, url_for, session, request
+from flask import Flask, redirect, url_for, session, request, jsonify
 from flask_cors import CORS
 from healthcheck import HealthCheck
 from prometheus_client import generate_latest
@@ -31,7 +31,29 @@ def create_app():
 
         @app.before_request
         def check_authenticated():
-            if 'user' not in session and request.path not in ['/login', '/auth', '/healthz', '/metrics', '/api/cron/notify-expired-tasks', '/api/cron/send-planned-mails']:
+            if 'user' in session:
+                return None
+
+            # Always allow static assets for the SPA to load.
+            if request.path.startswith('/assets/'):
+                return None
+
+            if request.path == '/favicon.ico':
+                return None
+
+            # Allow the external access flow only on the ForløbOverview route.
+            if request.path == '/forloeb-overview' and request.args.get('external', '').lower() == 'true':
+                return None
+
+            # Allow external API endpoints (they validate via accessKey).
+            if request.path.startswith('/api/external/'):
+                return None
+
+            # Allow userinfo lookup to return a JSON 401 (frontend falls back to Public).
+            if request.path == '/api/userinfo':
+                return None
+
+            if request.path not in ['/login', '/auth', '/healthz', '/metrics', '/api/cron/notify-expired-tasks', '/api/cron/send-planned-mails']:
                 return redirect(url_for("login"))
 
         @app.route("/login")
@@ -52,7 +74,7 @@ def create_app():
                 user_info['roles'] = user_info.get('resource_access', {}).get(KEYCLOAK_CLIENT_ID, {}).get('roles', ["Ny medarbejder", "Ansvarlig"])
                 return user_info, 200
             else:
-                return redirect(url_for('login'))
+                return jsonify({"error": "Not authenticated"}), 401
 
     # Create database client
     create_db_client()

--- a/python/src/models.py
+++ b/python/src/models.py
@@ -29,6 +29,11 @@ class Forløb(Base):
     mails = relationship('Mail', back_populates='forløb', cascade='all, delete')
     isPreparation = Column(Boolean, default=True)
 
+    # External (public) access via one-time emailed magic link.
+    # Store only a hash (never the raw key) + an expiry timestamp.
+    external_access_key_hash = Column(String, nullable=True)
+    external_access_expires_at = Column(DateTime, nullable=True)
+
 
 class Opgaveskabelon(Base):
     __tablename__ = 'Opgaveskabelon'

--- a/python/src/requirements.txt
+++ b/python/src/requirements.txt
@@ -10,6 +10,7 @@ prometheus-client
 python-dotenv
 requests==2.31.0
 requests-pkcs12==1.24
+rk-digi
 SQLAlchemy
 pandas
 flask-cors

--- a/python/src/requirements.txt
+++ b/python/src/requirements.txt
@@ -10,7 +10,7 @@ prometheus-client
 python-dotenv
 requests==2.31.0
 requests-pkcs12==1.24
-rk-digi==0.1.0
+rk-digi==1.1.0
 SQLAlchemy
 pandas
 flask-cors

--- a/python/src/requirements.txt
+++ b/python/src/requirements.txt
@@ -10,7 +10,7 @@ prometheus-client
 python-dotenv
 requests==2.31.0
 requests-pkcs12==1.24
-rk-digi
+rk-digi==0.1.0
 SQLAlchemy
 pandas
 flask-cors

--- a/python/src/utils/config.py
+++ b/python/src/utils/config.py
@@ -8,8 +8,8 @@ load_dotenv()
 
 # Test defaults: keep pytest runs deterministic regardless of local .env.
 if 'pytest' in sys.modules:
-	os.environ['DEBUG'] = 'False'
-	os.environ.setdefault('POD_NAME', 'test-pod')
+    os.environ['DEBUG'] = 'False'
+    os.environ.setdefault('POD_NAME', 'test-pod')
 
 
 DEBUG = os.getenv('DEBUG', 'False').lower() in ('true', '1', 't', 'yes', 'y')

--- a/python/src/utils/config.py
+++ b/python/src/utils/config.py
@@ -1,12 +1,18 @@
 import os
+import sys
 from dotenv import load_dotenv
 
 
 # loads .env file, will not overide already set enviroment variables (will do nothing when testing, building and deploying)
 load_dotenv()
 
+# Test defaults: keep pytest runs deterministic regardless of local .env.
+if 'pytest' in sys.modules:
+	os.environ['DEBUG'] = 'False'
+	os.environ.setdefault('POD_NAME', 'test-pod')
 
-DEBUG = os.getenv('DEBUG', 'True')
+
+DEBUG = os.getenv('DEBUG', 'False').lower() in ('true', '1', 't', 'yes', 'y')
 PORT = os.getenv('PORT', '8080')
 POD_NAME = os.getenv('POD_NAME', 'pod_name_not_set')
 DISABLE_KEYCLOAK = os.getenv('DISABLE_KEYCLOAK', 'False').lower() in ('true', '1', 't')

--- a/python/src/utils/config.py
+++ b/python/src/utils/config.py
@@ -38,8 +38,14 @@ KEYCLOAK_CLIENT_ID = os.environ["KEYCLOAK_CLIENT_ID"].strip()
 KEYCLOAK_CLIENT_SECRET = os.environ["KEYCLOAK_CLIENT_SECRET"].strip()
 COOKIE_SECRET = os.environ["COOKIE_SECRET"].strip()
 
-MAIL_SERVICE_URL = os.environ["MAIL_SERVICE_URL"].strip()
-MAIL_SERVICE_SENDER = os.environ["MAIL_SERVICE_SENDER"].strip()
+# SMTP settings for rk-digi EmailSender
+MAIL_SMTP_SERVER = os.getenv("MAIL_SMTP_SERVER", os.getenv("SMTP_SERVER", "")).strip()
+MAIL_SMTP_SENDER = os.getenv("MAIL_SMTP_SENDER", "").strip()
+MAIL_SMTP_PASSWORD = os.getenv("MAIL_SMTP_PASSWORD", "").strip()
+try:
+    MAIL_SMTP_PORT = int(os.getenv("MAIL_SMTP_PORT", os.getenv("SMTP_PORT", "587")))
+except ValueError:
+    MAIL_SMTP_PORT = 587
 
 # SFTP_HOST = os.environ['SFTP_HOST'].rstrip()
 # SFTP_USER = os.environ['SFTP_USER'].rstrip()

--- a/python/src/utils/logging.py
+++ b/python/src/utils/logging.py
@@ -1,11 +1,12 @@
 import sys
 import logging
 import re
+import time
 
 from werkzeug import serving
 from prometheus_client import Gauge, Counter, Summary
 
-from utils.config import DEBUG
+from utils.config import DEBUG, POD_NAME
 
 # Prometheus metricts
 
@@ -27,6 +28,10 @@ def set_logging_configuration():
     log_level = logging.DEBUG if DEBUG else logging.INFO
     logging.basicConfig(stream=sys.stdout, level=log_level, format='[%(asctime)s] %(levelname)s - %(name)s - %(module)s:%(funcName)s - %(message)s', datefmt='%d-%m-%Y %H:%M:%S')
     disable_endpoint_logs(('/metrics', '/healthz'))
+
+    # Ensure readiness metric is present for Prometheus scraping.
+    is_ready_gauge.labels(error_type="None", job_name=POD_NAME).set(1)
+    last_updated_gauge.set(int(time.time() * 1000))
 
 
 def disable_endpoint_logs(disabled_endpoints):

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -1,9 +1,10 @@
 from flask import jsonify
 import base64
 import logging
-import requests
 from datetime import datetime, timedelta
-from utils.config import MAIL_SERVICE_URL, MAIL_SERVICE_SENDER
+from rkdigi import EmailSender
+
+from utils.config import MAIL_SMTP_SENDER, MAIL_SMTP_PASSWORD, MAIL_SMTP_PORT, MAIL_SMTP_SERVER
 from models import Mail, MailAttachment
 from utils.db_connection import get_db_client
 from utils.pdf import create_pdf
@@ -33,24 +34,26 @@ def _to_bytes(data):
     raise TypeError(f"Unsupported attachment content type: {type(data)!r}")
 
 
-def _attachments_for_transport(attachments):
+def _attachments_for_rkdigi(attachments):
+    """Convert our attachment dicts to rk-digi EmailSender attachments.
+
+    rk-digi accepts attachments as either file paths (str) or (filename, bytes) tuples.
+    Our DB payloads are lists of dicts containing base64 strings or raw bytes.
+    """
     if attachments is None:
         return None
+
     transformed = []
     for attachment in attachments:
-        if attachment is None:
+        if not attachment:
             continue
-        filename = attachment.get("filename")
+        filename = attachment.get("filename") or "attachment"
         content = attachment.get("file_data", attachment.get("content"))
         content_bytes = _to_bytes(content)
         if content_bytes is None:
             raise ValueError("Attachment content is missing")
 
-        # Mail service expects a JSON byte array
-        transformed.append({
-            "filename": filename,
-            "content": {"data": list(content_bytes)},
-        })
+        transformed.append((filename, content_bytes))
     return transformed
 
 
@@ -147,7 +150,8 @@ def send_all_mails():
                 mail_dict.get('recipient'),
                 mail_dict.get('subject'),
                 mail_dict.get('body'),
-                attachments=mail_dict.get('attachments', None)
+                attachments=mail_dict.get('attachments', None),
+                reply_to=mail_dict.get('forløb', {}).get('admin', None)
             )
             # Fetch the actual Mail ORM object
             mail_obj = session.query(Mail).filter_by(MailID=mail_dict.get('id')).first()
@@ -165,36 +169,35 @@ def send_all_mails():
     return jsonify({"message": "Planned emails sent successfully", "count": total_count, "sent": sent_count}), 200
 
 
-def send_mail(recipient_email, subject, message, attachments=None):
+def send_mail(recipient_email, subject, message, attachments=None, reply_to=None):
     """
-    Sends an email via an API request.
+    Sends an email via SMTP using rk-digi.
     Parameters:
         sender_email (str): The sender's email address.
         subject (str): The subject of the email.
         message (str): The body of the email.
     """
-    headers = {
-        "Content-Type": "application/json"
-    }
-    payload = {
-        "from": MAIL_SERVICE_SENDER,
-        "to": recipient_email,
-        "title": subject,
-        "body": message,
-        "attachments": _attachments_for_transport(attachments)
-    }
-
     try:
-        response = requests.post(MAIL_SERVICE_URL, headers=headers, json=payload)
-        # Print response content regardless of status code
-        if response.status_code != 200:
-            logger.error(f"Mail service response ({response.status_code}): {response.text}")
-        response.raise_for_status()
+        if not MAIL_SMTP_SERVER or not MAIL_SMTP_SENDER or not MAIL_SMTP_PASSWORD:
+            raise ValueError("SMTP configuration is incomplete. Check environment variables.")
+
+        email_sender = EmailSender(
+            smtp_server=MAIL_SMTP_SERVER,
+            smtp_port=MAIL_SMTP_PORT,
+            sender_email=MAIL_SMTP_SENDER,
+            sender_password=MAIL_SMTP_PASSWORD,
+            sender_name="Randers Kommune Onboarding",
+            reply_to_email=reply_to
+        )
+        email_sender.send_email(
+            recipients=recipient_email,
+            subject=subject,
+            body=message,
+            attachments=_attachments_for_rkdigi(attachments),
+        )
         return True
-    except requests.exceptions.RequestException as e:
+    except Exception as e:
         logger.error(f"Error sending email to {recipient_email}: {e}")
-        if hasattr(e, 'response') and e.response is not None:
-            logger.error(f"Mail service error response ({e.response.status_code}): {e.response.text}")
         return False
 
 
@@ -227,7 +230,7 @@ def create_mail_external_access(forloeb, link: str, expires_at):
         expires_str = str(expires_at)
 
     message = (
-        "Hej\n\n"
+        f"Hej {forloeb.name}," + "\n\n" +
         "Du har anmodet om midlertidig adgang til dit onboardingforløb.\n\n"
         f"Åbn forløbet her (linket udløber {expires_str}):\n{link}\n\n"
         "Hvis du ikke selv har anmodet om dette link, kan du ignorere mailen.\n\n"

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -219,6 +219,23 @@ def create_mail_ansvarlig(new_opgave):
     return subject, message
 
 
+def create_mail_external_access(forloeb, link: str, expires_at):
+    subject = "Midlertidig adgang til onboardingforløb"
+    try:
+        expires_str = expires_at.astimezone(None).strftime('%d/%m %H:%M')
+    except Exception:
+        expires_str = str(expires_at)
+
+    message = (
+        "Hej\n\n"
+        "Du har anmodet om midlertidig adgang til dit onboardingforløb.\n\n"
+        f"Åbn forløbet her (linket udløber {expires_str}):\n{link}\n\n"
+        "Hvis du ikke selv har anmodet om dette link, kan du ignorere mailen.\n\n"
+        "Venlig hilsen\nRanders Kommune"
+    )
+    return subject, message
+
+
 def create_mail_expired_ansvarlig(opgave):
     opgave = {
         "ansvarlig": opgave.ansvarlig,

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -146,15 +146,19 @@ def send_all_mails():
     total_count = len(mails) if mails else 0
     try:
         for mail_dict in mails:
+            mail_obj = session.query(Mail).filter_by(MailID=mail_dict.get('id')).first()
+
+            reply_to = None
+            if mail_obj is not None and getattr(mail_obj, 'forløb', None) is not None:
+                reply_to = getattr(mail_obj.forløb, 'admin', None)
+
             status = send_mail(
                 mail_dict.get('recipient'),
                 mail_dict.get('subject'),
                 mail_dict.get('body'),
                 attachments=mail_dict.get('attachments', None),
-                reply_to=mail_dict.get('forløb', {}).get('admin', None)
+                reply_to=reply_to,
             )
-            # Fetch the actual Mail ORM object
-            mail_obj = session.query(Mail).filter_by(MailID=mail_dict.get('id')).first()
             if mail_obj:
                 mail_obj.isSent = status
                 if status:
@@ -180,6 +184,12 @@ def send_mail(recipient_email, subject, message, attachments=None, reply_to=None
     try:
         if not MAIL_SMTP_SERVER or not MAIL_SMTP_SENDER or not MAIL_SMTP_PASSWORD:
             raise ValueError("SMTP configuration is incomplete. Check environment variables.")
+
+        if EmailSender is None:
+            raise ImportError(
+                "EmailSender implementation not available. "
+                "Install/verify the rk-digi (rkdigi) package, or provide a compatible EmailSender."
+            )
 
         email_sender = EmailSender(
             smtp_server=MAIL_SMTP_SERVER,

--- a/python/src/utils/mail_service.py
+++ b/python/src/utils/mail_service.py
@@ -175,11 +175,15 @@ def send_all_mails():
 
 def send_mail(recipient_email, subject, message, attachments=None, reply_to=None):
     """
-    Sends an email via SMTP using rk-digi.
+    Sends an email via SMTP using rk-digi and the configured SMTP sender.
+
     Parameters:
-        sender_email (str): The sender's email address.
+        recipient_email (str or list[str]): Email address or list of addresses to send the email to.
         subject (str): The subject of the email.
         message (str): The body of the email.
+        attachments (list[dict] | None): Optional list of attachments, each with at least
+            "filename" and "file_data" (base64-encoded string). Defaults to None.
+        reply_to (str | None): Optional reply-to email address to set on the message.
     """
     try:
         if not MAIL_SMTP_SERVER or not MAIL_SMTP_SENDER or not MAIL_SMTP_PASSWORD:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ pytest==8.1.1
 pytest-cov==5.0.0
 pytest-env==1.1.3
 flake8==7.0.0
-rk-digi==0.1.0
+rk-digi==1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==8.1.1
 pytest-cov==5.0.0
 pytest-env==1.1.3
 flake8==7.0.0
+rk-digi==0.1.0

--- a/tests/external_access_throttle_test.py
+++ b/tests/external_access_throttle_test.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+from controllers import external_access_controller
+from models import Forløb
+
+
+def _make_session_with_forloeb(forloeb: Forløb):
+    session = MagicMock()
+    session.query.return_value.filter_by.return_value.first.return_value = forloeb
+    return session
+
+
+def test_request_external_access_cooldown_skips_resend():
+    app = Flask(__name__)
+
+    fixed_now = datetime(2026, 3, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Existing unexpired key issued 30 seconds ago -> within 1 minute cooldown.
+    forloeb = Forløb()
+    forloeb.ForløbID = 123
+    forloeb.usermail = "user@example.com"
+    forloeb.admin = "admin@example.com"
+    forloeb.external_access_key_hash = "deadbeef"
+    forloeb.external_access_expires_at = (fixed_now + timedelta(minutes=59, seconds=30)).replace(tzinfo=None)
+
+    session = _make_session_with_forloeb(forloeb)
+
+    with app.test_request_context(
+        "/api/external/request-access",
+        method="POST",
+        json={"forloebId": 123},
+        base_url="http://localhost",
+    ):
+        with patch.object(external_access_controller, "_utc_now", return_value=fixed_now):
+            with patch.object(external_access_controller.db_client, "get_session", return_value=session):
+                with patch.object(external_access_controller, "create_mail_external_access") as create_mail:
+                    with patch.object(external_access_controller, "send_mail") as send_mail:
+                        resp, status = external_access_controller.request_external_access()
+
+    assert status == 200
+    assert resp.get_json()["message"] == "If the forløb exists, an email has been sent."
+    send_mail.assert_not_called()
+    create_mail.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_request_external_access_after_cooldown_sends_email():
+    app = Flask(__name__)
+
+    fixed_now = datetime(2026, 3, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Existing unexpired key issued 2 minutes ago -> cooldown elapsed.
+    # issuance_time = fixed_now - 2 minutes -> expiry = issuance + 1 hour
+    forloeb = Forløb()
+    forloeb.ForløbID = 123
+    forloeb.usermail = "user@example.com"
+    forloeb.admin = "admin@example.com"
+    forloeb.external_access_key_hash = "deadbeef"
+    forloeb.external_access_expires_at = (fixed_now + timedelta(minutes=58)).replace(tzinfo=None)
+
+    session = _make_session_with_forloeb(forloeb)
+
+    with app.test_request_context(
+        "/api/external/request-access",
+        method="POST",
+        json={"forloebId": 123},
+        base_url="http://localhost",
+    ):
+        with patch.object(external_access_controller, "_utc_now", return_value=fixed_now):
+            with patch.object(external_access_controller.db_client, "get_session", return_value=session):
+                with patch.object(external_access_controller, "create_mail_external_access", return_value=("s", "m")):
+                    with patch.object(external_access_controller, "send_mail", return_value=True) as send_mail:
+                        resp, status = external_access_controller.request_external_access()
+
+    assert status == 200
+    assert resp.get_json()["message"] == "If the forløb exists, an email has been sent."
+    assert send_mail.call_count == 1
+    assert session.commit.call_count == 1

--- a/tests/mail_service_attachment_encoding_test.py
+++ b/tests/mail_service_attachment_encoding_test.py
@@ -1,14 +1,11 @@
 import base64
 from datetime import datetime
-from unittest.mock import MagicMock
-
-import requests
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from python.src.models import Base, Mail, MailAttachment
-from python.src.utils import mail_service
+from models import Base, Mail, MailAttachment
+from utils import mail_service
 
 
 class _TestDbClient:
@@ -96,21 +93,37 @@ def test_get_planned_mails_normalizes_legacy_bytes_in_db(monkeypatch):
 
 
 def test_send_mail_transports_attachments_as_json_byte_array(monkeypatch):
-    captured = {}
+    captured = {"init": None, "send": None}
 
-    def _fake_post(url, headers=None, json=None):
-        captured["url"] = url
-        captured["headers"] = headers
-        captured["json"] = json
-        res = MagicMock()
-        res.status_code = 200
-        res.text = "OK"
-        res.raise_for_status.return_value = None
-        return res
+    class _FakeEmailSender:
+        def __init__(
+            self,
+            smtp_server=None,
+            smtp_port=None,
+            sender_email=None,
+            sender_password=None,
+            sender_name=None,
+            reply_to_email=None,
+            reply_to_name=None,
+        ):
+            captured["init"] = {
+                "smtp_server": smtp_server,
+                "smtp_port": smtp_port,
+                "sender_email": sender_email,
+                "sender_password": sender_password,
+                "sender_name": sender_name,
+                "reply_to_email": reply_to_email,
+                "reply_to_name": reply_to_name,
+            }
 
-    monkeypatch.setattr(mail_service, "MAIL_SERVICE_URL", "http://mailservice.test/send")
-    monkeypatch.setattr(mail_service, "MAIL_SERVICE_SENDER", "sender@example.com")
-    monkeypatch.setattr(requests, "post", _fake_post)
+        def send_email(self, **kwargs):
+            captured["send"] = kwargs
+
+    monkeypatch.setattr(mail_service, "MAIL_SMTP_SERVER", "smtp.test")
+    monkeypatch.setattr(mail_service, "MAIL_SMTP_PORT", 25)
+    monkeypatch.setattr(mail_service, "MAIL_SMTP_SENDER", "sender@example.com")
+    monkeypatch.setattr(mail_service, "MAIL_SMTP_PASSWORD", "secret")
+    monkeypatch.setattr(mail_service, "EmailSender", _FakeEmailSender)
 
     raw = b"ABC"
     b64 = base64.b64encode(raw).decode("ascii")
@@ -121,4 +134,12 @@ def test_send_mail_transports_attachments_as_json_byte_array(monkeypatch):
         attachments=[{"filename": "a.bin", "file_data": b64}],
     )
     assert ok is True
-    assert captured["json"]["attachments"] == [{"filename": "a.bin", "content": {"data": [65, 66, 67]}}]
+
+    assert captured["init"]["smtp_server"] == "smtp.test"
+    assert captured["init"]["smtp_port"] == 25
+    assert captured["init"]["sender_email"] == "sender@example.com"
+    assert captured["init"]["sender_password"] == "secret"
+    assert captured["send"]["recipients"] == "to@example.com"
+    assert captured["send"]["subject"] == "Subject"
+    assert captured["send"]["body"] == "Body"
+    assert captured["send"]["attachments"] == [("a.bin", raw)]

--- a/tests/mail_service_delete_test.py
+++ b/tests/mail_service_delete_test.py
@@ -4,8 +4,8 @@ from flask import Flask
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from python.src.models import Base, Mail, MailAttachment
-from python.src.utils import mail_service
+from models import Base, Mail, MailAttachment
+from utils import mail_service
 
 
 class _TestDbClient:

--- a/vue/index.html
+++ b/vue/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
+    <meta name="referrer" content="no-referrer">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Onboarding</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">

--- a/vue/src/components/CourseOverview.vue
+++ b/vue/src/components/CourseOverview.vue
@@ -2,10 +2,11 @@
     import { ref, onMounted, watch } from 'vue'
     import { useRouter } from 'vue-router'
     import { getUserInfo } from '@/services/keycloakService.js'
+    import { getExternalUserInfo } from '@/services/externalAccessService.js'
     
-    import { getForloebByEmail, getForloebById, completeForloeb, deleteForloeb } from '@/services/forløbService.js'
+    import { getForloebByEmail, getForloebById, getForloebByIdExternal, completeForloeb, deleteForloeb } from '@/services/forløbService.js'
     import { getForloebsskabelonById, deleteForloebsskabelon } from '@/services/forløbsskabelonService.js'
-    import { getOpgaverByForloebID, getOpgaverByForloebIDAdmin, getOpgaverByForloebsskabelonID, getOpgaverByAnsvarligEmail } from '@/services/opgaveService.js'
+    import { getOpgaverByForloebID, getOpgaverByForloebIDExternal, getOpgaverByForloebIDAdmin, getOpgaverByForloebsskabelonID, getOpgaverByAnsvarligEmail } from '@/services/opgaveService.js'
     import TaskList from '@/components/TaskList.vue'
     import CourseItem from '@/components/CourseItem.vue'
     import Placeholder from '@/components/Placeholder.vue'
@@ -32,6 +33,14 @@
         ansvarligView: {
             type: Boolean,
             default: false
+        },
+        external: {
+            type: Boolean,
+            default: false
+        },
+        accessKey: {
+            type: String,
+            default: null
         }
     })
 
@@ -58,9 +67,89 @@
     const opgaver_template = ref([])
     const sortBy = ref(router.currentRoute.value.query.sort || 'deadline')
     const start_message_index = ref(-1)
+    const externalAccessDenied = ref(false)
 
     const fetchOpgaver = async () => {
+        // External access flow
         try {
+            if (props.external) {
+                externalAccessDenied.value = false
+                const externalInfoResponse = await getExternalUserInfo(props.id, props.accessKey)
+                userInfo.value = {
+                    roles: ['Public'],
+                    email: externalInfoResponse?.data?.email || '',
+                    isAdmin: false,
+                    isAnsvarlig: false,
+                    isMedarbejder: false,
+                }
+
+                const forloeb_response = await getForloebByIdExternal(props.id, props.accessKey)
+                isForloebFetched.value = true
+                forloeb.value = forloeb_response?.data
+
+                if (forloeb_response && forloeb.value == null) {
+                    isOpgaverFetched.value = true
+                    return
+                }
+
+                isUnderPreparation.value = forloeb.value?.isPreparation || false
+                isForloebCompleted.value = !isUnderPreparation.value && forloeb.value?.enddate ? new Date(forloeb.value.enddate) <= new Date() : false
+                isForloebOngoing.value = !isUnderPreparation.value && forloeb.value?.startdate ? new Date(forloeb.value.startdate) <= new Date() : false
+                forloeb_id.value = forloeb.value?.ForløbID
+                userTitle.value = forloeb.value?.userdq != '' ? forloeb.value?.userdq : forloeb.value?.usermail
+
+                if (forloeb.value?.opgave_grupper && Array.isArray(forloeb.value.opgave_grupper))
+                    forloeb.value?.opgave_grupper.sort((a, b) => a.name.localeCompare(b.name))
+
+                const opgaver_response = await getOpgaverByForloebIDExternal(forloeb_id.value, props.accessKey)
+
+                if (opgaver_response?.data == null) {
+                    console.warn('No tasks found')
+                    isOpgaverFetched.value = true
+                    return
+                }
+
+                if (!Array.isArray(opgaver_response.data))
+                    opgaver_response.data = [opgaver_response.data]
+
+                if (isUnderPreparation.value)
+                    opgaver_response.data.sort((a, b) => a.relativ_startdag - b.relativ_startdag)
+                else
+                    opgaver_response.data.sort((a, b) => new Date(a.slutdato) - new Date(b.slutdato))
+
+                opgaver_all.value = opgaver_response.data
+                completedPercentage.value = opgaver_all.value.length > 0 ? Math.round(opgaver_all.value.filter(opgave => opgave.result).length / opgaver_all.value.length * 100) : 0
+
+                if (isUnderPreparation.value)
+                {
+                    opgaver_template.value = opgaver_response.data
+                    start_message_index.value = opgaver_template.value
+                        .map(opgave => opgave.relativ_startdag > -1)
+                        .findIndex(opgave => opgave)
+                }
+                else
+                {
+                    for (const item of opgaver_response.data) {
+                        if (item.result)
+                            opgaver_completed.value.push(item)
+                        else
+                        if (new Date(item.startdato) > new Date())
+                            opgaver_future.value.push(item)
+                        else 
+                            opgaver_ongoing.value.push(item)
+                    }
+                    opgaver_future.value.sort((a, b) => new Date(a.startdato) - new Date(b.startdato))
+                    if (!isForloebOngoing.value && forloeb.value?.startdate)
+                        start_message_index.value = opgaver_future.value
+                            .map(opgave => new Date(opgave.startdato) > new Date(forloeb.value.startdate))
+                            .findIndex(opgave => opgave)
+                }
+
+                isOpgaverFetched.value = true
+                return
+            }
+
+            // Internal access flow (logged in AD users)
             if (userInfo.value) {
                 const headers = { usermail: userInfo.value.email }
                 // Get forloeb
@@ -150,6 +239,11 @@
 
         } catch (error) {
             console.error(error)
+
+            // If external access, show specific message if 403 Forbidden (likely expired or invalid link)
+            if (props.external && error?.response?.status === 403)
+                externalAccessDenied.value = true
+
             isForloebFetched.value = true
             isOpgaverFetched.value = true
         }
@@ -186,7 +280,8 @@
 
     onMounted(async () => {
         try {
-            userInfo.value = await getUserInfo()
+            if (!props.external)
+                userInfo.value = await getUserInfo()
             await fetchOpgaver()
         } catch (error) {
             console.error(error)
@@ -229,13 +324,16 @@
     })
 </script>
 <template>
-    <p v-if="forloeb == null && isForloebFetched && !props.ansvarligView" class="indent-tiny notification">
+    <p v-if="externalAccessDenied" class="indent-tiny notification">
+        <span class="bold">OBS</span>: Linket er ugyldigt eller udløbet. <router-link :to="`/forloeb-overview?id=${props.id}&external=true`">Anmod om et nyt link</router-link>.
+    </p>
+    <p v-if="forloeb == null && isForloebFetched && !props.ansvarligView && !externalAccessDenied" class="indent-tiny notification">
         <span class="bold">OBS</span>: Det ser ikke ud til, at du har et onboardingforløb tilknyttet.<br />Kontakt din leder eller administrator hvis du mener, at dette er en fejl.
     </p>
     <p v-if="forloeb != null && isForloebFetched && userInfo.isAdmin && isForloebOngoing && !forloeb.usermail.includes('@randers.dk')" class="indent-tiny notification yellow">
-        <span class="bold">OBS</span>: Forløbet er oprettet med medarbejderens private mailadresse. Husk at opdatere til medarbejderens nye Randers-mail, så onboardingforløbet kan tilgås.
+        <span class="bold">OBS</span>: Forløbet er oprettet med medarbejderens private mailadresse. Husk at opdatere til medarbejderens nye Randers-mail når medarbejderen er startet i kommunen.
     </p>
-    <p v-if="showDetails" class="indent-tiny bold uppercase p-header-adjust">
+    <p v-if="showDetails && forloeb != null" class="indent-tiny bold uppercase p-header-adjust">
         Oversigt
     </p>
     <CourseItem v-if="forloeb != null && isOpgaverFetched && showDetails"

--- a/vue/src/services/externalAccessService.js
+++ b/vue/src/services/externalAccessService.js
@@ -1,0 +1,19 @@
+import { apiRequest } from './apiRequest';
+
+const API_URL = 'api';
+
+export const requestExternalAccess = (forloebId) => {
+  return apiRequest({
+    method: 'post',
+    url: `${API_URL}/external/request-access`,
+    data: { forloebId },
+  });
+};
+
+export const getExternalUserInfo = (forloebId, accessKey) => {
+  const key = encodeURIComponent(accessKey || '');
+  return apiRequest({
+    method: 'get',
+    url: `${API_URL}/external/userinfo?forloebId=${forloebId}&accessKey=${key}`,
+  });
+};

--- a/vue/src/services/externalAccessService.js
+++ b/vue/src/services/externalAccessService.js
@@ -11,9 +11,13 @@ export const requestExternalAccess = (forloebId) => {
 };
 
 export const getExternalUserInfo = (forloebId, accessKey) => {
-  const key = encodeURIComponent(accessKey || '');
   return apiRequest({
     method: 'get',
-    url: `${API_URL}/external/userinfo?forloebId=${forloebId}&accessKey=${key}`,
+    url: `${API_URL}/external/userinfo?forloebId=${forloebId}`,
+    config: {
+      headers: {
+        'X-External-Access-Key': accessKey || '',
+      },
+    },
   });
 };

--- a/vue/src/services/forløbService.js
+++ b/vue/src/services/forløbService.js
@@ -26,6 +26,11 @@ export const getForloebById = (id, config) => {
   return apiRequest({ method: 'get', url: `${API_URL}/forloeb/${id}`, config });
 };
 
+export const getForloebByIdExternal = (id, accessKey) => {
+  const key = encodeURIComponent(accessKey || '');
+  return apiRequest({ method: 'get', url: `${API_URL}/external/forloeb/${id}?accessKey=${key}` });
+};
+
 export const getAllForloeb = () => {
   return apiRequest({ method: 'get', url: `${API_URL}/forloeb` });
 };

--- a/vue/src/services/forløbService.js
+++ b/vue/src/services/forløbService.js
@@ -27,8 +27,15 @@ export const getForloebById = (id, config) => {
 };
 
 export const getForloebByIdExternal = (id, accessKey) => {
-  const key = encodeURIComponent(accessKey || '');
-  return apiRequest({ method: 'get', url: `${API_URL}/external/forloeb/${id}?accessKey=${key}` });
+  return apiRequest({
+    method: 'get',
+    url: `${API_URL}/external/forloeb/${id}`,
+    config: {
+      headers: {
+        'X-External-Access-Key': accessKey || '',
+      },
+    },
+  });
 };
 
 export const getAllForloeb = () => {

--- a/vue/src/services/opgaveService.js
+++ b/vue/src/services/opgaveService.js
@@ -15,8 +15,15 @@ export const getOpgaverByForloebID = (forloebID, config) => {
 };
 
 export const getOpgaverByForloebIDExternal = (forloebID, accessKey) => {
-  const key = encodeURIComponent(accessKey || '');
-  return apiRequest({ method: 'get', url: `${API_URL}/external/opgave/forloeb/${forloebID}?accessKey=${key}` });
+  return apiRequest({
+    method: 'get',
+    url: `${API_URL}/external/opgave/forloeb/${forloebID}`,
+    config: {
+      headers: {
+        'X-External-Access-Key': accessKey || '',
+      },
+    },
+  });
 };
 
 export const getOpgaverByAnsvarligEmail = (config) => {

--- a/vue/src/services/opgaveService.js
+++ b/vue/src/services/opgaveService.js
@@ -14,6 +14,11 @@ export const getOpgaverByForloebID = (forloebID, config) => {
   return apiRequest({ method: 'get', url: `${API_URL}/opgave/forloeb/${forloebID}`, config });
 };
 
+export const getOpgaverByForloebIDExternal = (forloebID, accessKey) => {
+  const key = encodeURIComponent(accessKey || '');
+  return apiRequest({ method: 'get', url: `${API_URL}/external/opgave/forloeb/${forloebID}?accessKey=${key}` });
+};
+
 export const getOpgaverByAnsvarligEmail = (config) => {
   return apiRequest({ method: 'get', url: `${API_URL}/opgave/admin`, config });
 };

--- a/vue/src/views/ForløbOverview.vue
+++ b/vue/src/views/ForløbOverview.vue
@@ -15,8 +15,43 @@
     const userInfo = ref(null)
 
     const isExternal = computed(() => (route.query.external || '').toString().toLowerCase() === 'true')
-    const accessKey = computed(() => (route.query.accessKey || '').toString() || null)
+    const accessKey = ref(null)
     const externalRequestSent = ref(false)
+
+    const parseAccessKeyFromHash = (hash) => {
+        const raw = (hash || '').toString().replace(/^#/, '')
+        if (!raw)
+            return null
+
+        // Accept either `#accessKey=...` or a bare `#...` fragment.
+        if (raw.startsWith('accessKey='))
+            return raw.substring('accessKey='.length) || null
+
+        const params = new URLSearchParams(raw)
+        return params.get('accessKey') || raw || null
+    }
+
+    const syncAccessKey = () => {
+        if (!isExternal.value)
+        {
+            accessKey.value = null
+            return
+        }
+
+        const keyFromHash = parseAccessKeyFromHash(route.hash)
+        const storageKey = id.value ? `externalAccessKey:${id.value}` : null
+        const keyFromStorage = storageKey ? sessionStorage.getItem(storageKey) : null
+
+        accessKey.value = keyFromHash || keyFromStorage || null
+
+        // If we captured a key from the fragment, stash it and clear the fragment.
+        // This reduces the chance the key is copied/screenshot from the address bar.
+        if (storageKey && keyFromHash) {
+            sessionStorage.setItem(storageKey, keyFromHash)
+            if (route.hash)
+                router.replace({ query: route.query, hash: '' })
+        }
+    }
 
     const ensureIdOrRedirect = () => {
         if (!id.value || Number.isNaN(id.value))
@@ -49,10 +84,12 @@
 
     onMounted(() => {
         ensureIdOrRedirect()
+        syncAccessKey()
         sendExternalAccessEmail()
     })
-    watch(() => route.query, () => {
+    watch(() => route.fullPath, () => {
         ensureIdOrRedirect()
+        syncAccessKey()
         sendExternalAccessEmail()
     })
     

--- a/vue/src/views/ForløbOverview.vue
+++ b/vue/src/views/ForløbOverview.vue
@@ -1,28 +1,79 @@
 
 <script setup>
-    import { useRoute } from 'vue-router'
+    import { useRoute, useRouter } from 'vue-router'
     import CourseOverview from '@/components/CourseOverview.vue'
     import { getUserInfo } from '@/services/keycloakService.js'
-    import { ref } from 'vue'
+    import { onMounted, ref, computed, watch } from 'vue'
+    import { requestExternalAccess } from '@/services/externalAccessService.js'
 
     const route = useRoute()
-    const id = parseInt(route.query.id || route.query.tid, 10)
-    const isTemplate = route.query.tid !== undefined
+    const router = useRouter()
+    const id = computed(() => parseInt(route.query.id || route.query.tid, 10))
+    const isTemplate = computed(() => route.query.tid !== undefined)
 	const _expandItem = route.query.item
 	const expandItem = ref(_expandItem ? parseInt(_expandItem) : null)
     const userInfo = ref(null)
+
+    const isExternal = computed(() => (route.query.external || '').toString().toLowerCase() === 'true')
+    const accessKey = computed(() => (route.query.accessKey || '').toString() || null)
+    const externalRequestSent = ref(false)
+
+    const ensureIdOrRedirect = () => {
+        if (!id.value || Number.isNaN(id.value))
+            router.replace({ path: '/' })
+    }
 
     getUserInfo().then((response) => {
         userInfo.value = response
     }).catch((error) => {
         console.error('Error fetching user info:', error)
     })
+
+    const sendExternalAccessEmail = async () => {
+        if (!isExternal.value)
+            return
+        if (!id.value || Number.isNaN(id.value))
+            return
+        if (accessKey.value)
+            return
+        if (externalRequestSent.value)
+            return
+
+        externalRequestSent.value = true
+        try {
+            await requestExternalAccess(id.value)
+        } catch (error) {
+            console.error('Error requesting external access:', error)
+        }
+    }
+
+    onMounted(() => {
+        ensureIdOrRedirect()
+        sendExternalAccessEmail()
+    })
+    watch(() => route.query, () => {
+        ensureIdOrRedirect()
+        sendExternalAccessEmail()
+    })
     
 </script>
 
 <template>
     <div>
-        <CourseOverview v-if="userInfo != null && (userInfo.isAdmin || userInfo.isAnsvarlig)"
+        <div v-if="isExternal">
+            <p v-if="!accessKey" class="indent-tiny notification">
+                <span class="bold">OBS</span>: Tjek din email for et link til at åbne forløbet.
+            </p>
+            <CourseOverview v-else
+                            :id="id"
+                            :showDetails="true"
+                            :isTemplate="false"
+                            :expandItem="expandItem"
+                            :external="true"
+                            :accessKey="accessKey" />
+        </div>
+
+        <CourseOverview v-else-if="userInfo != null && (userInfo.isAdmin || userInfo.isAnsvarlig)"
                         :id="id"
                         :showDetails="true"
                         :isTemplate="isTemplate"


### PR DESCRIPTION
Allow external=true access without Keycloak redirect (serve assets + return /api/userinfo as 401 JSON when unauthenticated) Add DB fields on Forløb for external access key hash + expiry Implement /api/external/* endpoints to request email link and fetch read-only forløb/opgaver with key validation Add mail template for external access link
Update Vue ForløbOverview/CourseOverview to support external flow + “expired/invalid link” handling Fix config/logging/metrics initialization to keep tests deterministic and passing